### PR TITLE
use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -9,3 +9,4 @@ IntervalTrees
 julia 0.5
 PairwiseListMatrices
 Twiddle
+DataStructures

--- a/test/io/abif.jl
+++ b/test/io/abif.jl
@@ -16,7 +16,7 @@
     end
 
     get_bio_fmt_specimens()
-    path = Pkg.dir("BioSequences", "test", "BioFmtSpecimens", "ABI")
+    path = joinpath(dirname(dirname(@__FILE__)), "BioFmtSpecimens", "ABI")
     for specimen in YAML.load_file(joinpath(path, "index.yml"))
         valid = get(specimen, "valid", true)
         filepath = joinpath(path, specimen["filename"])


### PR DESCRIPTION
this allows the package to be installed and loaded from elsewhere