### PR TITLE
Added convenience method for removing gaps from a sequence.

### DIFF
--- a/docs/src/sequences/bioseq.md
+++ b/docs/src/sequences/bioseq.md
@@ -418,6 +418,8 @@ which are common in bioinformatics are also provided.
 reverse!
 complement!
 reverse_complement!
+ungap
+ungap!
 ```
 
 ```jldoctest

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -85,6 +85,8 @@ export
     complement!,
     reverse_complement,
     reverse_complement!,
+    ungap,
+    ungap!,
     mismatches,
     ispalindromic,
     hasambiguity,

--- a/src/sequence.jl
+++ b/src/sequence.jl
@@ -206,6 +206,16 @@ function isrepetitive(seq::Sequence, n::Integer=length(seq))
 end
 
 
+# Transformations
+# ---------------
+
+"Create a copy of a sequence with gap characters removed."
+ungap(seq::Sequence)  =  filter(x -> x != gap(eltype(seq)), seq)
+
+"Remove gap characters from a sequence. Modifies the input sequence."
+ungap!(seq::Sequence) = filter!(x -> x != gap(eltype(seq)), seq)
+
+
 # Printers
 # --------
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,9 +167,9 @@ include("symbols.jl")
     @test ungap(a) == dna"ACGG"
     @test ungap(b) == rna"ACGG"
     @test ungap(c) == aa"AKMV"
-    @test ungap!(a); a == dna"ACGG"
-    @test ungap!(b); b == dna"ACGG"
-    @test ungap!(c); c == aa"AKMV"
+    @test ungap!(a) === a && a == dna"ACGG"
+    @test ungap!(b) === b && b == rna"ACGG"
+    @test ungap!(c) === c && c == aa"AKMV"
 end
 
 @testset "BioSequences" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,6 +162,16 @@ end
 
 include("symbols.jl")
 
+@testset "Sequences" begin
+    a = dna"A-CG-G"; b = rna"A-CG-G"; c = aa"AK-MV-";
+    @test ungap(a) == dna"ACGG"
+    @test ungap(b) == rna"ACGG"
+    @test ungap(c) == aa"AKMV"
+    @test ungap!(a); a == dna"ACGG"
+    @test ungap!(b); b == dna"ACGG"
+    @test ungap!(c); c == aa"AKMV"
+end
+
 @testset "BioSequences" begin
     include("bioseq/conversion.jl")
     include("bioseq/basics.jl")


### PR DESCRIPTION
Just two methods for conveniently filtering gap characters from a sequence.
I couldn't see any similar functions in code, and it's a reasonably common thing to want to do.