### PR TITLE
An eachkmer iterator fix

### DIFF
--- a/src/eachkmer.jl
+++ b/src/eachkmer.jl
@@ -75,7 +75,7 @@ end
     k = kmersize(T)
     pos, kmer = state
     pos += it.step
-    has_ambiguous = false
+    ambig_or_gap = false
 
     # faster path: return the next overlapping kmer if possible
     if it.step < k && pos + k - 1 ≤ endof(it.seq)
@@ -83,19 +83,19 @@ end
         if it.step == 1
             nt = inbounds_getindex(it.seq, pos+offset)
             kmer = kmer << 2 | trailing_zeros(nt)
-            has_ambiguous |= isambiguous(nt)
+            ambig_or_gap |= (isambiguous(nt) || isgap(nt))
         else
             for i in 1:it.step
                 nt = inbounds_getindex(it.seq, pos+i-1+offset)
                 kmer = kmer << 2 | trailing_zeros(nt)
-                has_ambiguous |= isambiguous(nt)
+                ambig_or_gap |= (isambiguous(nt) || isgap(nt))
             end
         end
-        if !has_ambiguous
+        if !ambig_or_gap
             return (state[1], convert(T, state[2])), (pos, kmer)
         end
     end
-    
+
     # fallback
     while pos + k - 1 ≤ endof(it.seq)
         kmer, ok = extract_kmer_impl(it.seq, pos, k)
@@ -109,11 +109,11 @@ end
 
 function extract_kmer_impl(seq, from, k)
     kmer::UInt64 = 0
-    has_ambiguous = false
+    ambig_or_gap = false
     for i in 1:k
         nt = inbounds_getindex(seq, from+i-1)
         kmer = kmer << 2 | trailing_zeros(nt)
-        has_ambiguous |= isambiguous(nt)
+        ambig_or_gap |= (isambiguous(nt) || isgap(nt))
     end
-    return kmer, !has_ambiguous
+    return kmer, !ambig_or_gap
 end

--- a/src/eachkmer.jl
+++ b/src/eachkmer.jl
@@ -75,7 +75,7 @@ end
     k = kmersize(T)
     pos, kmer = state
     pos += it.step
-    uncertain = false
+    isok = true
 
     # faster path: return the next overlapping kmer if possible
     if it.step < k && pos + k - 1 ≤ endof(it.seq)
@@ -83,15 +83,15 @@ end
         if it.step == 1
             nt = inbounds_getindex(it.seq, pos+offset)
             kmer = kmer << 2 | trailing_zeros(nt)
-            uncertain |= !iscertain(nt)
+            isok &= iscertain(nt)
         else
             for i in 1:it.step
                 nt = inbounds_getindex(it.seq, pos+i-1+offset)
                 kmer = kmer << 2 | trailing_zeros(nt)
-                uncertain |= !iscertain(nt)
+                isok &= iscertain(nt)
             end
         end
-        if !uncertain
+        if isok
             return (state[1], convert(T, state[2])), (pos, kmer)
         end
     end
@@ -109,11 +109,11 @@ end
 
 function extract_kmer_impl(seq, from, k)
     kmer::UInt64 = 0
-    uncertain = false
+    isok = true
     for i in 1:k
         nt = inbounds_getindex(seq, from+i-1)
         kmer = kmer << 2 | trailing_zeros(nt)
-        uncertain |= !iscertain(nt)
+        isok &= iscertain(nt)
     end
-    return kmer, !uncertain
+    return kmer, isok
 end

--- a/src/eachkmer.jl
+++ b/src/eachkmer.jl
@@ -75,7 +75,7 @@ end
     k = kmersize(T)
     pos, kmer = state
     pos += it.step
-    ambig_or_gap = false
+    uncertain = false
 
     # faster path: return the next overlapping kmer if possible
     if it.step < k && pos + k - 1 ≤ endof(it.seq)
@@ -83,15 +83,15 @@ end
         if it.step == 1
             nt = inbounds_getindex(it.seq, pos+offset)
             kmer = kmer << 2 | trailing_zeros(nt)
-            ambig_or_gap |= (isambiguous(nt) || isgap(nt))
+            uncertain |= !iscertain(nt)
         else
             for i in 1:it.step
                 nt = inbounds_getindex(it.seq, pos+i-1+offset)
                 kmer = kmer << 2 | trailing_zeros(nt)
-                ambig_or_gap |= (isambiguous(nt) || isgap(nt))
+                uncertain |= !iscertain(nt)
             end
         end
-        if !ambig_or_gap
+        if !uncertain
             return (state[1], convert(T, state[2])), (pos, kmer)
         end
     end
@@ -109,11 +109,11 @@ end
 
 function extract_kmer_impl(seq, from, k)
     kmer::UInt64 = 0
-    ambig_or_gap = false
+    uncertain = false
     for i in 1:k
         nt = inbounds_getindex(seq, from+i-1)
         kmer = kmer << 2 | trailing_zeros(nt)
-        ambig_or_gap |= (isambiguous(nt) || isgap(nt))
+        uncertain |= !iscertain(nt)
     end
-    return kmer, !ambig_or_gap
+    return kmer, !uncertain
 end

--- a/test/kmers/eachkmer.jl
+++ b/test/kmers/eachkmer.jl
@@ -34,7 +34,7 @@
     @test isempty(collect(each(DNAKmer{1}, dna"NNNNNNNNNN")))
     @test_throws Exception each(DNAKmer{-1}, dna"ACGT")
     @test_throws Exception each(DNAKmer{33}, dna"ACGT")
-    @test collect(each(DNAKmer{3}, dna"AC-TGAG--TGC")) == [DNACodon(DNA_T, DNA_G, DNA_A),
-                                                           DNACodon(DNA_G, DNA_A, DNA_G),
-                                                           DNACodon(DNA_T, DNA_G, DNA_C)]
+    @test collect(each(DNAKmer{3}, dna"AC-TGAG--TGC")) == [(4, DNACodon(DNA_T, DNA_G, DNA_A)),
+                                                           (5, DNACodon(DNA_G, DNA_A, DNA_G)),
+                                                           (10, DNACodon(DNA_T, DNA_G, DNA_C))]
 end

--- a/test/kmers/eachkmer.jl
+++ b/test/kmers/eachkmer.jl
@@ -34,4 +34,7 @@
     @test isempty(collect(each(DNAKmer{1}, dna"NNNNNNNNNN")))
     @test_throws Exception each(DNAKmer{-1}, dna"ACGT")
     @test_throws Exception each(DNAKmer{33}, dna"ACGT")
+    @test collect(each(DNAKmer{3}, dna"AC-TGAG--TGC")) == [DNACodon(DNA_T, DNA_G, DNA_A),
+                                                           DNACodon(DNA_G, DNA_A, DNA_G),
+                                                           DNACodon(DNA_T, DNA_G, DNA_C)]
 end


### PR DESCRIPTION
@bicycle1885 This edits some lines of the eachkmer iterator, so as well as checking for ambigs, it also checks for gaps. Hope this is ok, if it is, the use of `each_kmer_impl` in some specific iterator I can write will actually allow me to do a lot of my work without the need for a whole new `Codon` type, which closes the issue and is a huge timesaving win!