### PR TITLE
add position-weighted matrix search

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, BioSequences
 
 makedocs()
 deploydocs(
-    deps = Deps.pip("mkdocs", "pygments", "mkdocs-material"),
+    deps = Deps.pip("mkdocs", "pygments", "mkdocs-material", "python-markdown-math"),
     repo = "github.com/BioJulia/BioSequences.jl.git",
     julia = "0.6",
     osname = "linux",

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,7 +23,7 @@ extra_css:
   - assets/Documenter.css
 
 extra_javascript:
-  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+  - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML
   - assets/mathjaxhelper.js
 
 # Extensions
@@ -33,6 +33,7 @@ markdown_extensions:
   - fenced_code
   - codehilite
   - def_list
+  - mdx_math
 
 # Page tree
 pages:

--- a/docs/src/search.md
+++ b/docs/src/search.md
@@ -215,6 +215,78 @@ Nullable{BioSequences.RE.RegexMatch{BioSequences.BioSequence{BioSequences.AminoA
 ```
 
 
+## Position weight matrix search
+
+A motif can also be specified using [position weight
+matrix](https://en.wikipedia.org/wiki/Position_weight_matrix) (PWM) in a
+probabilistic way. `search(seq, pwm, threshold)` method searches for the first
+position in the sequence where a score calculated using the PWM is greater than
+or equal to the threshold. More formally, denoting the sequence as ``S`` and the
+PWM value of symbol ``s`` at position ``j`` as ``M_{s,j}``, the score starting
+from a position ``p`` is defined as
+
+```math
+\operatorname{score}(S, p) = \sum_{i=1}^L M_{S[p+i-1],i}
+```
+
+and `search(S, M, t)` returns the smallest ``p`` that satisfies
+``\operatorname{score}(S, p) \ge t``.
+
+There are two kinds of matrices in this package: `PFM` and `PWM`. The `PFM` type
+is a position frequency matrix and stores symbol frequencies for each position.
+The `PWM` is a position weight matrix and stores symbol scores for each
+position. You can create a `PFM` from a set of sequences with the same length
+and then create a `PWM` from the `PFM` object.
+
+```jldoctest
+julia> kmers = DNAKmer.(["TTA", "CTA", "ACA", "TCA", "GTA"])
+5-element Array{BioSequences.Kmer{BioSymbols.DNA,3},1}:
+ TTA
+ CTA
+ ACA
+ TCA
+ GTA
+
+julia> pfm = PFM(kmers)  # sequence set => PFM
+4×3 BioSequences.PFM{BioSymbols.DNA,Int64}:
+ A  1  0  5
+ C  1  2  0
+ G  1  0  0
+ T  2  3  0
+
+julia> pwm = PWM(pfm)  # PFM => PWM
+4×3 BioSequences.PWM{BioSymbols.DNA,Float64}:
+ A -0.321928 -Inf       2.0
+ C -0.321928  0.678072 -Inf
+ G -0.321928 -Inf      -Inf
+ T  0.678072  1.26303  -Inf
+
+julia> pwm = PWM(pfm .+ 0.01)  # add pseudo counts to avoid infinite values
+4×3 BioSequences.PWM{BioSymbols.DNA,Float64}:
+ A -0.319068 -6.97728   1.99139
+ C -0.319068  0.673772 -6.97728
+ G -0.319068 -6.97728  -6.97728
+ T  0.673772  1.25634  -6.97728
+
+julia> pwm = PWM(pfm .+ 0.01, prior=[0.2, 0.3, 0.3, 0.2])  # GC-rich prior
+4×3 BioSequences.PWM{BioSymbols.DNA,Float64}:
+ A  0.00285965 -6.65535   2.31331
+ C -0.582103    0.410737 -7.24031
+ G -0.582103   -7.24031  -7.24031
+ T  0.9957      1.57827  -6.65535
+
+```
+
+The ``PWM_{s,j}`` matrix is computed from ``PFM_{s,j}`` and the prior
+probability ``p(s)`` as follows ([Wasserman2004]):
+```math
+\begin{align}
+    PWM_{s,j} &= \log_2 \frac{p(s,j)}{p(s)} \\
+    p(s,j)  &= \frac{PFM_{s,j}}{\sum_{s'} PFM_{s',j}}.
+\end{align}
+```
+
+
 ## Sequence composition
 
 Sequence composition can be easily calculated using the `composition` function:
@@ -272,3 +344,5 @@ julia> comp[DNAKmer("CGTA")]
 99
 
 ```
+
+[Wasserman2004]: https://doi.org/10.1038/nrg1315

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -153,12 +153,18 @@ export
     AminoAcidAlphabet,
     CharAlphabet,
 
+    # search
     ExactSearchQuery,
     ApproximateSearchQuery,
     approxsearch,
     approxsearchindex,
     approxrsearch,
     approxrsearchindex,
+    PFM,
+    PWM,
+    maxscore,
+    scoreat,
+
     ReferenceSequence,
     Demultiplexer,
     demultiplex,
@@ -221,6 +227,7 @@ include("abif/abif.jl")
 include("search/exact.jl")
 include("search/approx.jl")
 include("search/re.jl")
+include("search/pwm.jl")
 
 include("minhash.jl")
 

--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -124,7 +124,7 @@ end
 
 function truncate(s::String, len::Integer)
     if length(s) > len
-        return "$(String(collect(take(s, len - 1))))…"
+        return "$(String(collect(Iterators.take(s, len - 1))))…"
     else
         return s
     end

--- a/src/search/pwm.jl
+++ b/src/search/pwm.jl
@@ -1,0 +1,320 @@
+# Motif Search based on Position Weight Matrix
+# ============================================
+#
+# This file defines two types of matrices: PFM and PWM.  PFM is a thin wrapper
+# of Matrix and stores non-negative frequency values for each symbol and
+# position. PWM is a position weighted matrix and stores score values like PFM.
+# PFMs are mutable like usual matrices but PWMs cache partial scores to each
+# position and hence must be immutable so that updating operations won't cause
+# inconsistency.  PFM is created from a raw frequency matrix or a set of
+# sequences. PWM is created from a raw score matrix or a PFM.
+#
+# The motif search algorithm implemented here uses PWM. It tries to find the
+# nearest position from which the total score exceeds a specified threshold. The
+# algorithm stops searching immediately when it finds that the total score will
+# not exceeds the threshold even if the maximum partial score is achieved from
+# that position. This uses the partial score cache stored in a PWM object.
+
+"""
+Position frequency matrix.
+"""
+struct PFM{S,T<:Real} <: AbstractMatrix{T}
+    # row: symbol, column: position
+    data::Matrix{T}
+
+    function PFM{S,T}(m::AbstractMatrix{T}) where {S<:Union{DNA,RNA},T}
+        if size(m, 1) != 4
+            throw(ArgumentError("PFM must have four rows"))
+        end
+        return new{S,T}(m)
+    end
+end
+
+function Base.convert(::Type{PFM{S}}, m::AbstractMatrix{T}) where {S, T}
+    return PFM{S,T}(m)
+end
+
+function Base.convert(::Type{Matrix{T}}, m::PFM) where T
+    return convert(Matrix{T}, m.data)
+end
+
+function PFM(set)
+    return PFM(collect(set))
+end
+
+function PFM(set::Vector)
+    if isempty(set)
+        throw(ArgumentError("sequence set must be non-empty"))
+    end
+    S = eltype(eltype(set))
+    if S ∉ (DNA, RNA)
+        throw(ArgumentError("sequence element must be DNA or RNA"))
+    end
+    len = length(set[1])
+    freq = zeros(Int, (4, len))
+    for i in 1:endof(set)
+        seq = set[i]
+        if eltype(seq) != S
+            throw(ArgumentError("sequence element must be $(S)"))
+        elseif length(seq) != len
+            throw(ArgumentError("all sequences must be of the same length"))
+        end
+        for j in 1:len
+            s = seq[j]
+            if iscertain(s)  # ignore uncertain symbols
+                freq[index_nuc(s, j)] += 1
+            end
+        end
+    end
+    return convert(PFM{S}, freq)
+end
+
+function Base.IndexStyle(::Type{<:PFM})
+    return IndexLinear()
+end
+
+function Base.size(m::PFM)
+    return size(m.data)
+end
+
+function Base.getindex(m::PFM, i::Integer)
+    return m.data[i]
+end
+
+function Base.getindex(m::PFM{S}, s::S, j::Integer) where S<:Union{DNA,RNA}
+    return m.data[index_nuc(s, j)]
+end
+
+function Base.setindex!(m::PFM, val, i::Integer)
+    return setindex!(m.data, val, i)
+end
+
+function Base.setindex!(m::PFM, val, i::Integer, j::Integer)
+    return setindex!(m.data, val, i, j)
+end
+
+function Base.setindex!(m::PFM, val, s::S, j::Integer) where S<:Union{DNA,RNA}
+    return setindex!(m.data, val, index_nuc(s, j))
+end
+
+function Base.Broadcast._containertype(::Type{<:PFM})
+    return PFM
+end
+
+function Base.Broadcast.promote_containertype(::Type{PFM}, ::Type{Array})
+    return PFM
+end
+
+function Base.Broadcast.broadcast_c(f, ::Type{PFM}, A::PFM{S}, Bs...) where S
+    return PFM{S}(Base.Broadcast.broadcast_c(f, Array, A.data, Bs...))
+end
+
+function Base.show(io::IO, m::PFM{<:Union{DNA,RNA}})
+    show_nuc_matrix(io, m)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", m::PFM{<:Union{DNA,RNA}})
+    show_nuc_matrix(io, m)
+end
+
+
+"""
+Position weight matrix.
+"""
+struct PWM{S,T<:Real} <: AbstractMatrix{T}
+    # symbol type
+    symtype::Type{S}
+
+    # score matrix (row: symbols, column: position)
+    data::Matrix{T}
+
+    # maxscore[i] == sum(maximum(data, 1)[i:end])
+    maxscore::Vector{T}
+
+    function PWM{S,T}(pwm::AbstractMatrix) where {S<:Union{DNA,RNA},T}
+        if size(pwm, 1) != 4
+            throw(ArgumentError("PWM must have four rows"))
+        end
+        # make a copy for safety
+        return new{S,T}(S, copy(pwm), make_maxscore(pwm))
+    end
+end
+
+"""
+    PWM(pfm::PFM{<:Union{DNA,RNA}}; prior=fill(1/4,4))
+
+Create a position weight matrix from a position frequency matrix `pfm`.
+
+The positive weight matrix will be `log2.((pfm ./ sum(pfm, 1)) ./ prior)`.
+"""
+function PWM(pfm::PFM{S}; prior=fill(1/4, 4)) where S <: Union{DNA,RNA}
+    if !all(x -> x > 0, prior)
+        throw(ArgumentError("prior must be positive"))
+    elseif sum(prior) ≉ 1
+        throw(ArgumentError("prior must be sum to 1"))
+    end
+    prob = pfm ./ sum(pfm, 1)
+    return PWM{S,Float64}(log2.(prob ./ prior))
+end
+
+"""
+    PWM{T}(pwm::AbstractMatrix)
+
+Create a PWM from a raw matrix `pwm` (rows are symbols and columns are
+positions).
+
+Examples
+--------
+```julia-repl
+julia> pwm = [
+           0.065 -0.007 0.042 0.016 0.003  # A
+           0.025 -0.007 0.016 0.058 0.082  # C
+           0.066  0.085 0.070 0.054 0.010  # G
+           0.016  0.025 0.051 0.058 0.038  # T
+       ]
+4×5 Array{Float64,2}:
+ 0.065  -0.007  0.042  0.016  0.003
+ 0.025  -0.007  0.016  0.058  0.082
+ 0.066   0.085  0.07   0.054  0.01
+ 0.016   0.025  0.051  0.058  0.038
+
+julia> PWM{DNA}(pwm)
+BioSequences.PWM{BioSymbols.DNA,Float64}:
+ A  0.065 -0.007  0.042  0.016  0.003
+ C  0.025 -0.007  0.016  0.058  0.082
+ G  0.066  0.085  0.07   0.054  0.01
+ T  0.016  0.025  0.051  0.058  0.038
+
+```
+"""
+function PWM{T}(pwm::AbstractMatrix) where T <: Union{DNA,RNA}
+    return PWM{T,eltype(pwm)}(pwm)
+end
+
+function Base.IndexStyle(::Type{<:PWM})
+    return IndexLinear()
+end
+
+function Base.size(pwm::PWM)
+    return size(pwm.data)
+end
+
+function Base.getindex(pwm::PWM, i::Integer)
+    return getindex(pwm.data, i)
+end
+
+function Base.getindex(m::PWM{S}, s::S, j::Integer) where S<:Union{DNA,RNA}
+    return m.data[index_nuc(s, j)]
+end
+
+function Base.show(io::IO, pwm::PWM{<:Union{DNA,RNA}})
+    show_nuc_matrix(io, pwm)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", m::PWM{<:Union{DNA,RNA}})
+    show_nuc_matrix(io, m)
+end
+
+"""
+    maxscore(pwm::PWM)
+
+Return the maximum achievable score of `pwm`.
+"""
+function maxscore(pwm::PWM)
+    if size(pwm, 2) == 0
+        return zero(eltype(pwm))
+    else
+        return pwm.maxscore[1]
+    end
+end
+
+# Make an accumulated maximum score vector.
+function make_maxscore(pwm)
+    len = size(pwm, 2)
+    maxscore = Vector{eltype(pwm)}(len)
+    for j in len:-1:1
+        s = pwm[1,j]
+        for i in 2:size(pwm, 1)
+            s = max(s, pwm[i,j])
+        end
+        if j == len
+            maxscore[j] = s
+        else
+            maxscore[j] = s + maxscore[j+1]
+        end
+    end
+    return maxscore
+end
+
+"""
+    scoreat(seq::Sequence, pwm::PWM, start::Integer)
+
+Calculate the PWM score starting from `seq[start]`.
+"""
+function scoreat(seq::Sequence, pwm::PWM, start::Integer)
+    check_pwm(seq, pwm)
+    pwmlen = size(pwm, 2)
+    checkbounds(seq, start:start+pwmlen-1)
+    score = zero(eltype(pwm))
+    @inbounds for j in 0:pwmlen-1
+        x = seq[start+j]
+        score += iscertain(x) ? pwm[j<<2+trailing_zeros(x)+1] : zero(score)
+    end
+    return score
+end
+
+function Base.search(seq::Sequence, pwm::PWM, threshold::Real, start=1, stop=endof(seq))
+    if eltype(seq) == DNA || eltype(seq) == RNA
+        return search_nuc(seq, start:stop, pwm, convert(eltype(pwm), threshold))
+    else
+        throw(ArgumentError("no search algorithm for '$(typeof(seq))'"))
+    end
+end
+
+function check_pwm(seq, pwm::PWM{S}) where S <: Union{DNA,RNA}
+    if size(pwm, 1) != 4
+        throw(ArgumentError("matrix must have four rows"))
+    elseif eltype(seq) != S
+        throw(ArgumentError("sequence and PWM must have the same element type"))
+    end
+end
+
+function search_nuc(seq::Sequence, range::UnitRange{Int}, pwm::PWM{<:Union{DNA,RNA},S}, threshold::S) where S<:Real
+    check_pwm(seq, pwm)
+    checkbounds(seq, range)
+    pwmlen = size(pwm, 2)
+    for p in range.start:range.stop-pwmlen+1
+        score = zero(eltype(pwm))
+        @inbounds for j in 0:pwmlen-1
+            if score + pwm.maxscore[j+1] < threshold
+                break
+            end
+            x = seq[p+j]
+            score += iscertain(x) ? pwm[j<<2+trailing_zeros(x)+1] : zero(score)
+        end
+        if score ≥ threshold
+            return p
+        end
+    end
+    return 0
+end
+
+function index_nuc(s::Union{DNA,RNA}, j::Integer)
+    if !iscertain(s)
+        throw(ArgumentError(string("index symbol must be A, C, G or ", typeof(s) == DNA ? "T" : "U")))
+    end
+    return (j-1) << 2 + (trailing_zeros(s)) + 1
+end
+
+function show_nuc_matrix(io::IO, m::Union{PFM{S},PWM{S}}) where S<:Union{DNA,RNA}
+    compact(x) = string(x ≥ 0 ? " " : "", sprint(showcompact, x))
+    cells = hcat(['A', 'C', 'G', S == DNA ? 'T' : 'U'], compact.(m.data))
+    width = maximum(length.(cells), 1)
+    print(io, summary(m), ':')
+    for i in 1:size(cells, 1)
+        print(io, "\n ", rpad(cells[i,1], width[1]+1))
+        for j in 2:size(cells, 2)
+            print(io, rpad(cells[i,j], width[j]+1))
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -219,6 +219,7 @@ end
     include("search/exact.jl")
     include("search/approximate.jl")
     include("search/regex.jl")
+    include("search/pwm.jl")
 end
 
 include("translation.jl")

--- a/test/search/pwm.jl
+++ b/test/search/pwm.jl
@@ -1,0 +1,101 @@
+@testset "Position weight matrix" begin
+    @testset "PFM" begin
+        m = [
+            1   2  3
+            4   5  6
+            7   8  9
+            10 11 12
+        ]
+        pfm = PFM{DNA}(m)
+        @test pfm isa PFM{DNA,Int}
+        @test convert(Matrix, pfm) == m
+        @test all(pfm[i] == m[i] for i in eachindex(pfm))
+        @test all(pfm[i,j] == m[i,j] for i in 1:4, j in 1:3)
+        @test all(pfm[ACGT[i],j] == m[i,j] for i in 1:4, j in 1:3)
+        @test startswith(sprint(show, pfm), string(summary(pfm), ":\n"))
+        @test_throws ArgumentError PFM{DNA}(vcat(m, [13 14 15]))
+
+        # indexing
+        pfm[5] = 100
+        @test pfm[5] == pfm[DNA_A,2] == 100
+        pfm[2,3] = 200
+        @test pfm[2,3] == pfm[DNA_C,3] == 200
+        pfm[DNA_G,1] = 300
+        @test pfm[3,1] == pfm[DNA_G,1] == 300
+        @test_throws ArgumentError pfm[DNA_N,1]
+
+        # broadcast
+        @test log.(pfm) isa PFM{DNA,Float64}
+        @test log.(pfm) == PFM{DNA}(log.(m))
+        @test pfm .+ 1 isa PFM{DNA,Int}
+        @test pfm .+ 1 == PFM{DNA}(m .+ 1)
+        @test pfm .+ 1.1 isa PFM{DNA,Float64}
+        @test pfm .+ 1.1 == PFM{DNA}(m .+ 1.1)
+        @test pfm .+ [0,1,2,3] isa PFM{DNA,Int}
+        @test pfm .+ [0,1,2,3] == PFM{DNA}(m .+ [0,1,2,3])
+
+        set = DNAKmer.(split(
+        """
+        ACG
+        ATG
+        AGG
+        ACC
+        """))
+        pfm = PFM(set)
+        @test pfm == [
+            4 0 0  # A
+            0 2 1  # C
+            0 1 3  # G
+            0 1 0  # T
+        ]
+        @test pfm == PFM(Set(set))
+        @test_throws ArgumentError PFM(DNAKmer[])
+        @test_throws ArgumentError PFM(["foo"])
+        @test_throws ArgumentError PFM([DNAKmer("AA"), RNAKmer("AA")])
+        @test_throws ArgumentError PFM([DNAKmer("AA"), DNAKmer("AAA")])
+    end
+
+    @testset "PWM" begin
+        m = [
+             1  2  3
+             4  5  6
+             7  8  9
+            10 11 12
+        ]
+        pfm = PFM{DNA}(m)
+        pwm = PWM(pfm)
+        raw = log2.((pfm ./ sum(pfm, 1)) ./ fill(1/4, 4))
+        @test pwm isa PWM{DNA,Float64}
+        @test pwm == raw
+        @test PWM(pfm, prior=[0.1, 0.4, 0.4, 0.1]) == log2.((pfm ./ sum(pfm, 1)) ./ [0.1, 0.4, 0.4, 0.1])
+        @test PWM(pfm) == PWM{DNA}(raw)
+        @test maxscore(pwm) ≈ sum(maximum(raw, 1))
+        @test maxscore(PWM{DNA}(zeros(4, 0))) === 0.0
+        @test PWM(pfm .+ 0.1) isa PWM{DNA,Float64}  # pseudo count
+        @test_throws ArgumentError PWM{DNA}(hcat(m, [13, 14, 15]))
+        @test_throws ArgumentError PWM(pfm, prior=normalize([0,1,2,3], 1))
+        @test_throws ArgumentError PWM(pfm, prior=normalize([0,1,2,3], 1).+1e-3)
+        @test all(pwm[i] === pwm[i] for i in eachindex(pwm))
+        @test all(pwm[i,j] === raw[i,j] for i in 1:4, j in 1:3)
+        @test all(pwm[ACGT[i],j] === pwm[i,j] for i in 1:4, j in 1:3)
+        @test startswith(sprint(show, pwm), string(summary(pwm), ":\n"))
+    end
+
+    @testset "search" begin
+        seq = dna"ACGATNATCGCGTANTG"
+        data = [
+            1.0 0.1 0.2
+            0.0 0.2 0.3
+            0.1 0.2 0.0
+            0.9 0.5 0.2
+        ]
+        pwm = PWM{DNA}(data)
+        @test maxscore(pwm) == 1.8
+        @test scoreat(seq, pwm, 1) === 1.2
+        @test search(seq, pwm, 1.0) === 1
+        @test search(seq, pwm, 1.4) === 4
+        @test search(seq, pwm, 1.8) === 7
+        @test search(seq, pwm, 2.0) === 0
+        @test_throws ArgumentError search(convert(RNASequence, seq), pwm, 1.0)
+    end
+end


### PR DESCRIPTION
This adds functionality to search motifs using position-weighted matrix (PWM), which is similar to `matchPWM` of [Biostrings](https://bioconductor.org/packages/release/bioc/html/Biostrings.html). 

TODO:
- [ ] ~support amino acid sequences~
- [x] docs
- [x] more tests
- [x] benchmark against Biostrings