### PR TITLE
Make minhash function for generic reader

### DIFF
--- a/src/minhash.jl
+++ b/src/minhash.jl
@@ -93,17 +93,7 @@ function minhash(seqs::Vector{T}, k::Integer, s::Integer) where {T<:BioSequence}
     return MinHashSketch(kmerhashes, k)
 end
 
-function minhash(seqs::FASTA.Reader, k::Integer, s::Integer)
-    kmerhashes = UInt64[]
-    for seq in seqs
-        kmerminhash!(DNAKmer{k}, sequence(seq), s, kmerhashes)
-    end
-
-    length(kmerhashes) < s && error("failed to generate enough hashes")
-    return MinHashSketch(kmerhashes, k)
-end
-
-function minhash(seqs::FASTQ.Reader, k::Integer, s::Integer)
+function minhash(seqs::BioCore.IO.AbstractReader, k::Integer, s::Integer)
     kmerhashes = UInt64[]
     for seq in seqs
         kmerminhash!(DNAKmer{k}, sequence(seq), s, kmerhashes)

--- a/src/minhash.jl
+++ b/src/minhash.jl
@@ -102,3 +102,13 @@ function minhash(seqs::FASTA.Reader, k::Integer, s::Integer)
     length(kmerhashes) < s && error("failed to generate enough hashes")
     return MinHashSketch(kmerhashes, k)
 end
+
+function minhash(seqs::FASTQ.Reader, k::Integer, s::Integer)
+    kmerhashes = UInt64[]
+    for seq in seqs
+        kmerminhash!(DNAKmer{k}, sequence(seq), s, kmerhashes)
+    end
+
+    length(kmerhashes) < s && error("failed to generate enough hashes")
+    return MinHashSketch(kmerhashes, k)
+end


### PR DESCRIPTION
Minor addition. Decided to use this with fastq files - works great. One thing: will only work if the reader has a `sequence()` defined for it. Is there any situation where this wouldn't work?