### PR TITLE
implement bit-parallel GC counter

### DIFF
--- a/src/bioseq/operators.jl
+++ b/src/bioseq/operators.jl
@@ -16,6 +16,40 @@ function Base.count(f::Function, seq::BioSequence)
     return n
 end
 
+function count_gc(seq::BioSequence{<:Union{DNAAlphabet{4},RNAAlphabet{4}}})
+    function count(x)
+        # bit parallel counter of GC
+        a =  x & 0x1111111111111111
+        c = (x & 0x2222222222222222) >> 1
+        g = (x & 0x4444444444444444) >> 2
+        t = (x & 0x8888888888888888) >> 3
+        return count_ones((c | g) & ~(a | t))
+    end
+    n = 0
+    i = bitindex(seq, 1)
+    stop = bitindex(seq, endof(seq) + 1)
+    if offset(i) != 0 && i < stop
+        o = offset(i)
+        n += count(seq.data[index(i)] >> o)
+        i += 64 - o
+    end
+    while i < stop - 64
+        @inbounds n += count(seq.data[index(i)])
+        i += 64
+    end
+    if i < stop
+        o = offset(stop)
+        if o == 0
+            mask = 0xFFFFFFFFFFFFFFFF
+        else
+            mask = UInt64(1) << o - 1
+        end
+        n += count(seq.data[index(i)] & mask)
+    end
+    return n
+end
+
+
 # Site counting
 # -------------
 

--- a/src/bioseq/operators.jl
+++ b/src/bioseq/operators.jl
@@ -27,22 +27,18 @@ function count_gc(seq::BioSequence{<:Union{DNAAlphabet{2},RNAAlphabet{2}}})
     i = bitindex(seq, 1)
     stop = bitindex(seq, endof(seq) + 1)
     if offset(i) != 0 && i < stop
+        # align the bit index to the beginning of a block boundary
         o = offset(i)
-        n += count(seq.data[index(i)] >> o)
+        n += count((seq.data[index(i)] >> o) & bitmask(stop - i))
         i += 64 - o
+        @assert offset(i) == 0
     end
-    while i < stop - 64
+    while i ≤ stop - 64
         @inbounds n += count(seq.data[index(i)])
         i += 64
     end
     if i < stop
-        o = offset(stop)
-        if o == 0
-            mask = 0xFFFFFFFFFFFFFFFF
-        else
-            mask = UInt64(1) << o - 1
-        end
-        n += count(seq.data[index(i)] & mask)
+        n += count(seq.data[index(i)] & bitmask(offset(stop)))
     end
     return n
 end
@@ -60,22 +56,18 @@ function count_gc(seq::BioSequence{<:Union{DNAAlphabet{4},RNAAlphabet{4}}})
     i = bitindex(seq, 1)
     stop = bitindex(seq, endof(seq) + 1)
     if offset(i) != 0 && i < stop
+        # align the bit index to the beginning of a block boundary
         o = offset(i)
-        n += count(seq.data[index(i)] >> o)
+        n += count((seq.data[index(i)] >> o) & bitmask(stop - i))
         i += 64 - o
+        @assert offset(i) == 0
     end
-    while i < stop - 64
+    while i ≤ stop - 64
         @inbounds n += count(seq.data[index(i)])
         i += 64
     end
     if i < stop
-        o = offset(stop)
-        if o == 0
-            mask = 0xFFFFFFFFFFFFFFFF
-        else
-            mask = UInt64(1) << o - 1
-        end
-        n += count(seq.data[index(i)] & mask)
+        n += count(seq.data[index(i)] & bitmask(offset(stop)))
     end
     return n
 end

--- a/src/bitindex.jl
+++ b/src/bitindex.jl
@@ -30,3 +30,8 @@ Base.start(i::BitIndex) = 1
 Base.done(i::BitIndex, s) = s > 2
 Base.next(i::BitIndex, s) = ifelse(s == 1, (index(i), 2), (offset(i), 3))
 Base.show(io::IO, i::BitIndex) = print(io, '(', index(i), ", ", offset(i), ')')
+
+# Create a bit mask that fills least significant `n` bits (`n` must be a
+# non-negative integer).
+bitmask(n::Integer) = bitmask(UInt64, n)
+bitmask(::Type{T}, n::Integer) where {T} = (one(T) << n) - one(T)

--- a/src/sequence.jl
+++ b/src/sequence.jl
@@ -118,7 +118,7 @@ Calculate GC content of `seq`.
 """
 function gc_content(seq::Sequence)
     if !(eltype(seq) <: NucleicAcid)
-        error("elements must be nucleotides")
+        throw(ArgumentError("not a nucleic acid sequence"))
     end
     if isempty(seq)
         return 0.0

--- a/src/sequence.jl
+++ b/src/sequence.jl
@@ -107,6 +107,10 @@ end
 Base.findfirst(seq::Sequence, val) = findnext(seq, val, 1)
 Base.findlast(seq::Sequence, val) = findprev(seq, val, endof(seq))
 
+
+# GC content
+# ----------
+
 """
     gc_content(seq::Sequence)
 
@@ -116,19 +120,15 @@ function gc_content(seq::Sequence)
     if !(eltype(seq) <: NucleicAcid)
         error("elements must be nucleotides")
     end
-
-    gc = 0
-    for x in seq
-        if isGC(x)
-            gc += 1
-        end
-    end
-
     if isempty(seq)
         return 0.0
     else
-        return gc / length(seq)
+        return count_gc(seq) / length(seq)
     end
+end
+
+function count_gc(seq::Sequence)
+    return count(isGC, seq)
 end
 
 

--- a/test/bioseq/gc_content.jl
+++ b/test/bioseq/gc_content.jl
@@ -4,6 +4,7 @@
     @test gc_content(dna"ACGT") === 0.5
     @test gc_content(dna"CGGC") === 1.0
     @test gc_content(dna"ACATTGTGTATAACAAAAGG") === 6 / 20
+    @test gc_content(dna"GAGGCGTTTATCATC"[2:end]) === 6 / 14
 
     @test gc_content(DNAKmer("")) === 0.0
     @test gc_content(DNAKmer("AATA")) === 0.0
@@ -16,6 +17,7 @@
     @test gc_content(rna"ACGU") === 0.5
     @test gc_content(rna"CGGC") === 1.0
     @test gc_content(rna"ACAUUGUGUAUAACAAAAGG") === 6 / 20
+    @test gc_content(rna"GAGGCGUUUAUCAUC"[2:end]) === 6 / 14
 
     @test gc_content(RNAKmer("")) === 0.0
     @test gc_content(RNAKmer("AAUA")) === 0.0
@@ -24,4 +26,14 @@
     @test gc_content(RNAKmer("ACAUUGUGUAUAACAAAAGG")) === 6 / 20
 
     @test_throws Exception gc_content(aa"ARN")
+
+    srand(1234)
+    for _ in 1:200
+        s = randdnaseq(rand(1:100))
+        @test gc_content(s) === count(isGC, s) / length(s)
+        @test gc_content(BioSequence{DNAAlphabet{2}}(s)) === count(isGC, s) / length(s)
+        i = rand(1:endof(s))
+        j = rand(i-1:endof(s))
+        @test gc_content(s[i:j]) === (j < i ? 0.0 : count(isGC, s[i:j]) / (j - i + 1))
+    end
 end


### PR DESCRIPTION
~Still an experimental implementation.~

This is a faster version of `gc_content` using a bit-parallel algorithm as I mentioned in https://github.com/BioJulia/BioSequences.jl/issues/27#issuecomment-342789976. I was inspired to try a bit-parallel algorithm by @timbitz, so I think you are interested in this pull request.

```
julia> srand(1234); seq = randdnaseq(1_000_000);

julia> @benchmark count(isGC, seq)
BenchmarkTools.Trial:
  memory estimate:  16 bytes
  allocs estimate:  1
  --------------
  minimum time:     7.788 ms (0.00% GC)
  median time:      8.220 ms (0.00% GC)
  mean time:        8.548 ms (0.00% GC)
  maximum time:     12.825 ms (0.00% GC)
  --------------
  samples:          585
  evals/sample:     1

julia> @benchmark BioSequences.count_gc(seq)
BenchmarkTools.Trial:
  memory estimate:  16 bytes
  allocs estimate:  1
  --------------
  minimum time:     171.186 μs (0.00% GC)
  median time:      171.251 μs (0.00% GC)
  mean time:        181.268 μs (0.00% GC)
  maximum time:     600.158 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1

```