### PR TITLE
Bugfix: Writing FASTA sequences when width <= 0

### DIFF
--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -102,7 +102,7 @@ function Base.copy(record::Record)
 end
 
 function Base.write(io::IO, record::Record)
-    return unsafe_write(io, pointer(record.data, first(record.filled), length(record.filled)))
+    return unsafe_write(io, pointer(record.data, first(record.filled)), length(record.filled))
 end
 
 function Base.print(io::IO, record::Record)

--- a/test/io/FASTA.jl
+++ b/test/io/FASTA.jl
@@ -86,21 +86,30 @@
 
         # Check round trip
         output = IOBuffer()
-        writer = FASTA.Writer(output, width=60)
+        writer = FASTA.Writer(output, width = 60)
+        outputB = IOBuffer()
+        writerB = FASTA.Writer(outputB, width = -1)
         expected_entries = Any[]
         for seqrec in open(FASTA.Reader, filename)
             write(writer, seqrec)
+            write(writerB, seqrec)
             push!(expected_entries, seqrec)
         end
         flush(writer)
+        flush(writerB)
 
         seekstart(output)
+        seekstart(outputB)
         read_entries = FASTA.Record[]
+        read_entriesB = FASTA.Record[]
         for seqrec in FASTA.Reader(output)
             push!(read_entries, seqrec)
         end
-
+        for seqrec in FASTA.Reader(outputB)
+            push!(read_entriesB, seqrec)
+        end
         @test expected_entries == read_entries
+        @test expected_entries == read_entriesB
     end
 
     get_bio_fmt_specimens()


### PR DESCRIPTION
A typo / bracket error prevented writing sequences to file when the width of the FASTA was <= 0. This fixes that error.