### PR TITLE
Allow translate(seq) to take a DNASequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Automatic convertion of `DNASequence` to `RNASequence` when translating sequences.
+- Automatic conversion of `DNASequence` to `RNASequence` when translating sequences.
 
 ## [1.0.0] - 2018-08-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
 - Automatic conversion of `DNASequence` to `RNASequence` when translating sequences.
 - Add `alternative_start` keyword argument to translate().
 - Add abstract type for kmer iterators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Automatic convertion of `DNASequence` to `RNASequence` when translating sequences.
 
 ## [1.0.0] - 2018-08-23
 ### Added

--- a/docs/src/sequences/bioseq.md
+++ b/docs/src/sequences/bioseq.md
@@ -444,7 +444,8 @@ we describe it here in more detail.
 The [`translate`](@ref) funtion translates a sequence of codons in a RNA sequence
 to a amino acid sequence besed on a genetic code mapping. The `BioSequences` module
 contains all NCBI defined genetic codes and they are registered in
-[`ncbi_trans_table`](@ref).
+[`ncbi_trans_table`](@ref). DNA sequences are automatically converted to RNA before
+being translated.
 
 ```@docs
 translate

--- a/src/geneticcode.jl
+++ b/src/geneticcode.jl
@@ -310,13 +310,13 @@ Base3  = TCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAG
 # -----------
 
 """
-    translate(rna_seq, code=standard_genetic_code, allow_ambiguous_codons=true)
+    translate(seq, code=standard_genetic_code, allow_ambiguous_codons=true)
 
-Translate an `RNASequence` to an `AminoAcidSequence`.
+Translate an `RNASequence` or a `DNASequence` to an `AminoAcidSequence`.
 
 Translation uses genetic code `code` to map codons to amino acids. See
 `ncbi_trans_table` for available genetic codes.
-If codons in the given RNA sequence cannot determine a unique amino acid, they
+If codons in the given sequence cannot determine a unique amino acid, they
 will be translated to `AA_X` if `allow_ambiguous_codons` is `true` and otherwise
 result in an error.
 """
@@ -356,6 +356,10 @@ function translate(seq::RNASequence, code::GeneticCode, allow_ambiguous_codons::
         j += 1
     end
     return aaseq
+end
+
+function translate(seq::DNASequence; kwargs...)
+    return translate(convert(RNASequence, seq); kwargs...)
 end
 
 function try_translate_ambiguous_codon(code::GeneticCode,

--- a/src/geneticcode.jl
+++ b/src/geneticcode.jl
@@ -320,13 +320,13 @@ If codons in the given sequence cannot determine a unique amino acid, they
 will be translated to `AA_X` if `allow_ambiguous_codons` is `true` and otherwise
 result in an error.
 """
-function translate(seq::RNASequence;
+function translate(seq::Union{RNASequence, BioSequence{RNAAlphabet{2}}};
                    code::GeneticCode=standard_genetic_code,
                    allow_ambiguous_codons::Bool = true)
     return translate(seq, code, allow_ambiguous_codons)
 end
 
-function translate(seq::RNASequence, code::GeneticCode, allow_ambiguous_codons::Bool)
+function translate(seq::Union{RNASequence, BioSequence{RNAAlphabet{2}}}, code::GeneticCode, allow_ambiguous_codons::Bool)
     aaseqlen, r = divrem(length(seq), 3)
     if r != 0
         error("RNASequence length is not divisible by three. Cannot translate.")
@@ -360,6 +360,10 @@ end
 
 function translate(seq::DNASequence; kwargs...)
     return translate(convert(RNASequence, seq); kwargs...)
+end
+
+function translate(seq::BioSequence{DNAAlphabet{2}}, kwargs...)
+    return translate(convert(BioSequence{RNAAlphabet{2}}, seq), kwargs...)
 end
 
 function try_translate_ambiguous_codon(code::GeneticCode,

--- a/test/translation.jl
+++ b/test/translation.jl
@@ -52,6 +52,9 @@
     # DNASequence
     @test translate(dna"ATGTAA") == aa"M*"
 
+    # Alternative start codons
+    @test translate(rna"GUGUAA", alternative_start = true) == aa"M*"
+
     @test_throws Exception translate(rna"ACGUACGU")  # can't translate non-multiples of three
     # can't translate N
     @test_throws Exception translate(rna"ACGUACGNU", allow_ambiguous_codons=false)

--- a/test/translation.jl
+++ b/test/translation.jl
@@ -45,6 +45,9 @@
     @test translate(rna"YUGMGG") == aa"LR"
     @test translate(rna"GAYGARGAM") == aa"DEX"
 
+    # DNASequence
+    @test translate(dna"ATGTAA") == aa"M*"
+
     @test_throws Exception translate(rna"ACGUACGU")  # can't translate non-multiples of three
     # can't translate N
     @test_throws Exception translate(rna"ACGUACGNU", allow_ambiguous_codons=false)

--- a/test/translation.jl
+++ b/test/translation.jl
@@ -45,6 +45,10 @@
     @test translate(rna"YUGMGG") == aa"LR"
     @test translate(rna"GAYGARGAM") == aa"DEX"
 
+    # BioSequences{RNAAlphabet{2}}
+    @test translate(BioSequence{RNAAlphabet{2}}("AAAUUUGGGCCC")) == translate(rna"AAAUUUGGGCCC")
+    @test translate(BioSequence{DNAAlphabet{2}}("AAATTTGGGCCC")) == translate(dna"AAATTTGGGCCC")
+
     # DNASequence
     @test translate(dna"ATGTAA") == aa"M*"
 

--- a/test/translation.jl
+++ b/test/translation.jl
@@ -45,7 +45,6 @@
     @test translate(rna"YUGMGG") == aa"LR"
     @test translate(rna"GAYGARGAM") == aa"DEX"
 
-    @test_throws Exception translate(dna"ACGTACGTA") # can't translate DNA
     @test_throws Exception translate(rna"ACGUACGU")  # can't translate non-multiples of three
     # can't translate N
     @test_throws Exception translate(rna"ACGUACGNU", allow_ambiguous_codons=false)


### PR DESCRIPTION
# Allow translate(seq) to take a DNASequence
Currently `translate(seq::DNASequence)` throws a MethodError. While `translate(convert(RNASequence, seq))` might make sense biologically, it is unnecessarily verbose. I propose doing this conversion automatically.

## Types of changes

This PR implements the following changes:

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
