### PR TITLE
Fixed entry indexing in ABIF files

### DIFF
--- a/src/abif/reader.jl
+++ b/src/abif/reader.jl
@@ -133,7 +133,7 @@ end
 # extract all tags in file
 function read_abif_tags(input::IO, header::AbifDirEntry)
     tags = AbifDirEntry[]
-    for index in 1:header.num_elements
+    for index in 0:header.num_elements-1
         start = header.data_offset + index * header.element_size
         tag = parse_directory(input, start)
         push!(tags, tag)


### PR DESCRIPTION
# Fixed entry indexing in ABIF files

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

The current entry indexing in ABIF files is offset by 1. The problem is on these lines: https://github.com/BioJulia/BioSequences.jl/blob/95d64dc58c034cb2a0af54f179478d585e970796/src/abif/reader.jl#L136-L137

You can see the same code in Biopython:
https://github.com/biopython/biopython/blob/c04ecd81509cb8f3563e7d09ac03c6bd8d8d009a/Bio/SeqIO/AbiIO.py#L458-L459

The index in BioSequences.jl runs from 1 to the number of entries, whereas the index in Biopython correctly runs from 0 to the number of elements - 1.

This has the effect of skipping the first entry. In the BioFmtSpecimens/ABI/310.ab1 file, for example, the AEPt1 entry is skipped and only a single AEPt entry is returned. The [ABIF spec doc](http://www6.appliedbiosystems.com/support/software_community/ABIF_File_Format.pdf#page=33) notes that there are indeed two of these. Changing the index as in this PR correctly returns both AEPt1 and AEPt2.

There is also another, more painful issue. In the BioFmtSpecimens examples there seem to be some null bytes at the end that get parsed into a dummy entry at the end due to the offset:
```
Dict{String,Array{UInt8,1}} with 1 entry:
  "\0\0\0\0" => UInt8[]
```
However, the data files I'm working with do not have these null bytes so the parsing fails with:
```
EOFError: read end of file
```
Biopython, on the other hand, does not fail to parse these.

The tests all pass with this change, but that's only because they just check for pass/fail of parsing. To catch this issue we'd need samples without the trailing null bytes or tests that verify the presence of entry names.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
