### PR TITLE
Type specialization for faster kmer iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- Add abstract type for kmer iterators
+- :racehorse: Faster kmer iteration
 
 ## [1.0.0] - 2018-08-23
 ### Added

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,4 +7,3 @@ Combinatorics
 IndexableBitVectors 1.0.0
 IntervalTrees
 Twiddle 1.0.0
-DataStructures

--- a/src/bioseq/transformations.jl
+++ b/src/bioseq/transformations.jl
@@ -309,8 +309,6 @@ end
     reverse_complement!(seq)
 
 Make a reversed complement sequence of `seq` in place.
-
-Ambiguous nucleotides are left as-is.
 """
 function reverse_complement!(seq::BioSequence{A}) where {A<:NucAlphs}
     return complement!(reverse!(seq))
@@ -320,8 +318,6 @@ end
     reverse_complement(seq)
 
 Make a reversed complement sequence of `seq`.
-
-Ambiguous nucleotides are left as-is.
 """
 function reverse_complement(seq::BioSequence{A}) where {A<:NucAlphs}
     return complement!(reverse(seq))

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -58,7 +58,7 @@ function Composition(seq::AminoAcidSequence)
     return Composition{AminoAcid}(count_array2dict(counts, alphabet(AminoAcid)))
 end
 
-function Composition(iter::EachKmerIterator{T}) where {T<:Kmer}
+function Composition(iter::AbstractKmerIterator{T}) where {T<:Kmer}
     counts = Dict{T,Int}()
     if kmersize(T) ≤ 8
         # This is faster for short k-mers.
@@ -86,7 +86,7 @@ end
 
 Calculate composition of biological symbols in `seq` or k-mers in `kmer_iter`.
 """
-function composition(iter::Union{Sequence,EachKmerIterator})
+function composition(iter::Union{Sequence,AbstractKmerIterator})
     return Composition(iter)
 end
 

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -74,8 +74,7 @@ function Composition(iter::AbstractKmerIterator{T}) where {T<:Kmer}
         end
     else
         for (_, x) in iter
-            get!(counts, x, 0)
-            counts[x] += 1
+            counts[x] = get(counts, x, 0) + 1
         end
     end
     return Composition{T}(counts)

--- a/src/eachkmer.jl
+++ b/src/eachkmer.jl
@@ -81,9 +81,18 @@ function each(::Type{Kmer{T,K}}, seq::Sequence, step::Integer=1) where {T,K}
     end
 end
 
-eachkmer(seq::BioSequence{A}, K::Integer, step::Integer=1) where {A<:DNAAlphabet} = each(DNAKmer{Int(K)}, seq, step)
-eachkmer(seq::BioSequence{A}, K::Integer, step::Integer=1) where {A<:RNAAlphabet} = each(RNAKmer{Int(K)}, seq, step)
-eachkmer(seq::ReferenceSequence, K::Integer, step::Integer=1) = each(DNAKmer{Int(K)}, seq, step)
+function eachkmer(seq::BioSequence{A}, K::Integer, step::Integer=1) where {A<:DNAAlphabet}
+    Base.depwarn("eachkmer is depreceated: type instability means it is too slow. Please use each(::Type{Kmer{T,K}}, seq, step) instead", :eachkmer)
+    return each(DNAKmer{Int(K)}, seq, step)
+end
+function eachkmer(seq::BioSequence{A}, K::Integer, step::Integer=1) where {A<:RNAAlphabet}
+    Base.depwarn("eachkmer is depreceated: type instability means it is too slow. Please use each(::Type{Kmer{T,K}}, seq, step) instead", :eachkmer)
+    return each(RNAKmer{Int(K)}, seq, step)
+end
+function eachkmer(seq::ReferenceSequence, K::Integer, step::Integer=1)
+    Base.depwarn("eachkmer is depreceated: type instability means it is too slow. Please use each(::Type{Kmer{T,K}}, seq, step) instead", :eachkmer)
+    return each(DNAKmer{Int(K)}, seq, step)
+end
 
 Base.eltype(::Type{<:AbstractKmerIterator{T,S}}) where {T,S} = Tuple{Int,T}
 Base.IteratorSize(::Type{<:AbstractKmerIterator{T,S}}

--- a/src/eachkmer.jl
+++ b/src/eachkmer.jl
@@ -6,6 +6,26 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
+# Note about the variable names:
+
+# it.step is the distance from start of one kmer to start of next
+#
+# filled is the number of nucleotides in a kmer that has the correct value set.
+# e.g. when moving from xxxxxxx to yyyyyyy, filled goes from K to 3.
+# when moving from xxxxxxx to zzzzzzz, filled goes from K to 0.
+#
+# increment is how far the index jumps ahead when going to the next kmer.
+# for close kmers where no jump is possible, it's 1, else it can be arbitrary high.
+#
+#       |---------- step --------|
+#       xxxxxxx                  zzzzzzz
+# -------------------------------------------------------------
+#           yyyyyyy
+#             |---- increment ---|
+#
+# The state returned at each iteration is the state upon return, not the state
+# needed for the following iteration.
+
 abstract type AbstractKmerIterator{T,S} end
 
 struct EveryKmerIterator{T<:Kmer,S<:Sequence} <: AbstractKmerIterator{T,S}
@@ -19,10 +39,29 @@ struct SpacedKmerIterator{T<:Kmer,S<:Sequence} <: AbstractKmerIterator{T,S}
     start::Int
     step::Int
     stop::Int
-    filled::Int # This is cached values for speed
-    increment::Int # This is cached values for speed
+    filled::Int # This is cached for speed
+    increment::Int # This is cached for speed
 end
 
+"""
+    each(::Type{Kmer{T,k}}, seq::Sequence[, step=1])
+
+Initialize an iterator over all k-mers in a sequence `seq` skipping ambiguous
+nucleotides without changing the reading frame.
+
+# Arguments
+* `Kmer{T,k}`: k-mer type to enumerate.
+* `seq`: a nucleotide sequence.
+* `step=1`: the number of positions between iterated k-mers
+
+# Examples
+```
+# iterate over DNA codons
+for (pos, codon) in each(DNAKmer{3}, dna"ATCCTANAGNTACT", 3)
+    @show pos, codon
+end
+```
+"""
 function each(::Type{Kmer{T,K}}, seq::Sequence, step::Integer=1) where {T,K}
     if eltype(seq) ∉ (DNA, RNA)
         throw(ArgumentError("element type must be either DNA or RNA nucleotide"))
@@ -47,19 +86,27 @@ eachkmer(seq::ReferenceSequence, K::Integer, step::Integer=1) = each(DNAKmer{Int
 Base.eltype(::Type{<:AbstractKmerIterator{T,S}}) where {T,S} = Tuple{Int,T}
 Base.IteratorSize(::Type{<:AbstractKmerIterator{T,S}}) where {T,S} = Base.SizeUnknown()
 
+positions(::Type{Kmer{T, K}}) where {T, K} = max(1, K) # Only to handle K = 0
+Base.step(x::EveryKmerIterator) = 1
+Base.step(x::SpacedKmerIterator) = x.step
+
+# A nucleotide with bitvalue B has kmer-bitvalue kmerbits[B+1].
+# ambiguous nucleotides have no kmervalue, here set to 0xff
 const kmerbits = (0xff, 0x00, 0x01, 0xff,
                   0x02, 0xff, 0xff, 0xff,
                   0x03, 0xff, 0xff, 0xff,
                   0xff, 0xff, 0xff, 0xff)
 
+# Initializer for TwoBitNucs
 function Base.iterate(it::AbstractKmerIterator{T,S}) where {T,S<:BioSequence{<:TwoBitNucs}}
-    filled, i, kmer = 0, 1, UInt64(0)
+    filled, i, kmer = 0, it.start, UInt64(0)
+
     while i ≤ it.stop
         nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
         @inbounds val = kmerbits[nt + 1]
         kmer = kmer << 2 | val
         filled += 1
-        if filled == kmersize(T)
+        if filled == positions(T)
             return (1, T(kmer)), (i, kmer)
         end
         i += 1
@@ -67,96 +114,83 @@ function Base.iterate(it::AbstractKmerIterator{T,S}) where {T,S<:BioSequence{<:T
     return nothing
 end
 
-function Base.iterate(it::EveryKmerIterator{T,S}, state::Tuple{Int,UInt64}) where {T,S<:BioSequence{<:TwoBitNucs}}
+function Base.iterate(it::EveryKmerIterator{T,S}, state
+    ) where {T,S<:BioSequence{<:TwoBitNucs}}
     i, kmer = state
     i += 1
-    pos = i - kmersize(T) + 1
+
     if i > it.stop
         return nothing
     else
         nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
         @inbounds val = kmerbits[nt + 1]
         kmer = kmer << 2 | val
+        pos = i - positions(T) + 1
         return (pos, T(kmer)), (i, kmer)
     end
 end
 
-function Base.iterate(it::SpacedKmerIterator{T,S}, state::Tuple{Int,UInt64}) where {T,S<:BioSequence{<:TwoBitNucs}}
-    i, kmer = state
-    filled = it.filled
-    i += max(1, it.step - kmersize(T) + 1)
-    while i ≤ it.stop
-        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
-        val = kmerbits[nt + 1] # inbounds
-        kmer = kmer << 2 | val
-        filled += 1
-        if filled == kmersize(T)
-            pos = i - kmersize(T) + 1
-            return (pos, T(kmer)), (i, kmer)
-        end
-        i += 1
-    end
-    return nothing
-end
-
-function Base.iterate(it::AbstractKmerIterator{T,S}) where {T,S<:BioSequence{<:FourBitNucs}}
-    filled, i, kmer = 0, 1, UInt64(0)
-    while i ≤ it.stop
-        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
-        if nt == 0xff # ambiguous
-            filled = 0
-        else
-            filled += 1
-            @inbounds val = kmerbits[nt + 1]
-            kmer = kmer << 2 | val
-        end
-        if filled == kmersize(T)
-            pos = i - kmersize(T) + 1
-            return (pos, T(kmer)), (i, kmer)
-        end
-        i += 1
-    end
-    return nothing
-end
-
-function Base.iterate(it::EveryKmerIterator{T,S}, state::Tuple{Int,UInt64}) where {T,S<:BioSequence{<:FourBitNucs}}
-    i, kmer = state
-    i += 1
-    filled = kmersize(T) - 1
-    while i ≤ it.stop
-        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
-        if nt == 0xff # ambiguous
-            filled = 0
-        else
-            filled += 1
-            @inbounds val = kmerbits[nt + 1]
-            kmer = kmer << 2 | val
-        end
-        if filled == kmersize(T)
-            pos = i - kmersize(T) + 1
-            return (pos, T(kmer)), (i, kmer)
-        end
-        i += 1
-    end
-    return nothing
-end
-
-function Base.iterate(it::SpacedKmerIterator{T,S}, state::Tuple{Int,UInt64}) where {T,S<:BioSequence{<:FourBitNucs}}
+function Base.iterate(it::SpacedKmerIterator{T,S}, state
+    ) where {T,S<:BioSequence{<:TwoBitNucs}}
     i, kmer = state
     filled = it.filled
     i += it.increment
+
     while i ≤ it.stop
         nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
-        if nt == 0xff # ambiguous
+        @inbounds val = kmerbits[nt + 1]
+        kmer = kmer << 2 | val
+        filled += 1
+        if filled == positions(T)
+            pos = i - positions(T) + 1
+            return (pos, T(kmer)), (i, kmer)
+        end
+        i += 1
+    end
+    return nothing
+end
+
+function Base.iterate(it::EveryKmerIterator{T,S}, state=(it.start-1,1,UInt64(0))
+    ) where {T,S<:Union{ReferenceSequence, BioSequence{<:FourBitNucs}}}
+    i, filled, kmer = state
+    i += 1
+    filled -= 1
+
+    while i ≤ it.stop
+        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
+        @inbounds val = kmerbits[nt + 1]
+        kmer = kmer << 2 | val
+        filled = ifelse(val == 0xff, 0, filled+1)
+
+        if filled == positions(T)
+            pos = i - positions(T) + 1
+            return (pos, T(kmer)), (i, positions(T), kmer)
+        end
+        i += 1
+    end
+    return nothing
+end
+
+@inline function Base.iterate(it::SpacedKmerIterator{T,S}, state=(it.start-it.increment, 1, 0, UInt64(0))
+    ) where {T,S<:Union{ReferenceSequence, BioSequence{<:FourBitNucs}}}
+    i, pos, filled, kmer = state
+    i += it.increment
+
+    while i ≤ it.stop
+        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
+        @inbounds val = kmerbits[nt + 1]
+        if val == 0xff # ambiguous
             filled = 0
+            # Find the beginning of next possible kmer after i
+            pos = i + it.step - Core.Intrinsics.urem_int(i-pos, it.step)
+            i = pos - 1
         else
             filled += 1
-            @inbounds val = kmerbits[nt + 1]
             kmer = kmer << 2 | val
         end
-        if filled == kmersize(T)
-            pos = i - kmersize(T) + 1
-            return (pos, T(kmer)), (i, kmer)
+        if filled == positions(T)
+            state = (i, i - positions(T) + 1 + it.step, it.filled, kmer)
+            return (pos, T(kmer)), state
         end
         i += 1
     end

--- a/src/eachkmer.jl
+++ b/src/eachkmer.jl
@@ -6,32 +6,23 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
-# Iterate through every k-mer in a nucleotide sequence
-struct EachKmerIterator{T<:Kmer,S<:Sequence}
+abstract type AbstractKmerIterator{T,S} end
+
+struct EveryKmerIterator{T<:Kmer,S<:Sequence} <: AbstractKmerIterator{T,S}
     seq::S
-    step::Int
     start::Int
+    stop::Int
 end
 
-"""
-    each(::Type{Kmer{T,k}}, seq::Sequence[, step=1])
-
-Initialize an iterator over all k-mers in a sequence `seq` skipping ambiguous
-nucleotides without changing the reading frame.
-
-# Arguments
-* `Kmer{T,k}`: k-mer type to enumerate.
-* `seq`: a nucleotide sequence.
-* `step=1`: the number of positions between iterated k-mers
-
-# Examples
-```
-# iterate over DNA codons
-for (pos, codon) in each(DNAKmer{3}, dna"ATCCTANAGNTACT", 3)
-    @show pos, codon
+struct SpacedKmerIterator{T<:Kmer,S<:Sequence} <: AbstractKmerIterator{T,S}
+    seq::S
+    start::Int
+    step::Int
+    stop::Int
+    filled::Int # This is cached values for speed
+    increment::Int # This is cached values for speed
 end
-```
-"""
+
 function each(::Type{Kmer{T,K}}, seq::Sequence, step::Integer=1) where {T,K}
     if eltype(seq) ∉ (DNA, RNA)
         throw(ArgumentError("element type must be either DNA or RNA nucleotide"))
@@ -40,66 +31,134 @@ function each(::Type{Kmer{T,K}}, seq::Sequence, step::Integer=1) where {T,K}
     elseif step < 1
         throw(ArgumentError("step size must be positive"))
     end
-    return EachKmerIterator{Kmer{T,K},typeof(seq)}(seq, step, 1)
+    if step == 1
+        return EveryKmerIterator{Kmer{T,K},typeof(seq)}(seq, 1, lastindex(seq))
+    else
+        filled = max(0, K - step)
+        increment = max(1, step - K + 1)
+        return SpacedKmerIterator{Kmer{T,K},typeof(seq)}(seq, 1, step, lastindex(seq), filled, increment)
+    end
 end
 
 eachkmer(seq::BioSequence{A}, K::Integer, step::Integer=1) where {A<:DNAAlphabet} = each(DNAKmer{Int(K)}, seq, step)
 eachkmer(seq::BioSequence{A}, K::Integer, step::Integer=1) where {A<:RNAAlphabet} = each(RNAKmer{Int(K)}, seq, step)
 eachkmer(seq::ReferenceSequence, K::Integer, step::Integer=1) = each(DNAKmer{Int(K)}, seq, step)
 
-Base.eltype(::Type{EachKmerIterator{T,S}}) where {T,S} = Tuple{Int,T}
+Base.eltype(::Type{<:AbstractKmerIterator{T,S}}) where {T,S} = Tuple{Int,T}
+Base.IteratorSize(::Type{<:AbstractKmerIterator{T,S}}) where {T,S} = Base.SizeUnknown()
 
-function Base.IteratorSize(::Type{EachKmerIterator{T,S}}) where {T,S}
-    return Base.SizeUnknown()
-end
+const kmerbits = (0xff, 0x00, 0x01, 0xff,
+                  0x02, 0xff, 0xff, 0xff,
+                  0x03, 0xff, 0xff, 0xff,
+                  0xff, 0xff, 0xff, 0xff)
 
-Base.iterate(it::EachKmerIterator) = iterate(it, (it.start, UInt64(0)))
-
-function Base.iterate(
-        it::EachKmerIterator{T},
-        state::Tuple{Int, UInt64}) where {T}
-
-    k = kmersize(T)
-    pos, kmer = state
-    isok = true
-
-    # faster path: return the next overlapping kmer if possible
-    if it.step < k && pos + k - 1 ≤ lastindex(it.seq) && pos != it.start
-        offset = k - it.step
-        if it.step == 1
-            nt = inbounds_getindex(it.seq, pos+offset)
-            kmer = kmer << 2 | trailing_zeros(nt)
-            isok &= iscertain(nt)
-        else
-            for i in 1:it.step
-                nt = inbounds_getindex(it.seq, pos+i-1+offset)
-                kmer = kmer << 2 | trailing_zeros(nt)
-                isok &= iscertain(nt)
-            end
+function Base.iterate(it::AbstractKmerIterator{T,S}) where {T,S<:BioSequence{<:TwoBitNucs}}
+    filled, i, kmer = 0, 1, UInt64(0)
+    while i ≤ it.stop
+        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
+        @inbounds val = kmerbits[nt + 1]
+        kmer = kmer << 2 | val
+        filled += 1
+        if filled == kmersize(T)
+            return (1, T(kmer)), (i, kmer)
         end
-        if isok
-            return (pos, T(kmer)), (pos+it.step, kmer)
-        end
+        i += 1
     end
-
-    while pos + k - 1 ≤ lastindex(it.seq)
-        kmer, ok = extract_kmer_impl(it.seq, pos, k)
-        if ok
-            return (pos, T(kmer)), (pos+it.step, kmer)
-        end
-        pos += it.step
-    end
-
     return nothing
 end
 
-function extract_kmer_impl(seq, from, k)
-    kmer::UInt64 = 0
-    isok = true
-    for i in 1:k
-        nt = inbounds_getindex(seq, from+i-1)
-        kmer = kmer << 2 | trailing_zeros(nt)
-        isok &= iscertain(nt)
+function Base.iterate(it::EveryKmerIterator{T,S}, state::Tuple{Int,UInt64}) where {T,S<:BioSequence{<:TwoBitNucs}}
+    i, kmer = state
+    i += 1
+    pos = i - kmersize(T) + 1
+    if i > it.stop
+        return nothing
+    else
+        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
+        @inbounds val = kmerbits[nt + 1]
+        kmer = kmer << 2 | val
+        return (pos, T(kmer)), (i, kmer)
     end
-    return kmer, isok
+end
+
+function Base.iterate(it::SpacedKmerIterator{T,S}, state::Tuple{Int,UInt64}) where {T,S<:BioSequence{<:TwoBitNucs}}
+    i, kmer = state
+    filled = it.filled
+    i += max(1, it.step - kmersize(T) + 1)
+    while i ≤ it.stop
+        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
+        val = kmerbits[nt + 1] # inbounds
+        kmer = kmer << 2 | val
+        filled += 1
+        if filled == kmersize(T)
+            pos = i - kmersize(T) + 1
+            return (pos, T(kmer)), (i, kmer)
+        end
+        i += 1
+    end
+    return nothing
+end
+
+function Base.iterate(it::AbstractKmerIterator{T,S}) where {T,S<:BioSequence{<:FourBitNucs}}
+    filled, i, kmer = 0, 1, UInt64(0)
+    while i ≤ it.stop
+        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
+        if nt == 0xff # ambiguous
+            filled = 0
+        else
+            filled += 1
+            @inbounds val = kmerbits[nt + 1]
+            kmer = kmer << 2 | val
+        end
+        if filled == kmersize(T)
+            pos = i - kmersize(T) + 1
+            return (pos, T(kmer)), (i, kmer)
+        end
+        i += 1
+    end
+    return nothing
+end
+
+function Base.iterate(it::EveryKmerIterator{T,S}, state::Tuple{Int,UInt64}) where {T,S<:BioSequence{<:FourBitNucs}}
+    i, kmer = state
+    i += 1
+    filled = kmersize(T) - 1
+    while i ≤ it.stop
+        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
+        if nt == 0xff # ambiguous
+            filled = 0
+        else
+            filled += 1
+            @inbounds val = kmerbits[nt + 1]
+            kmer = kmer << 2 | val
+        end
+        if filled == kmersize(T)
+            pos = i - kmersize(T) + 1
+            return (pos, T(kmer)), (i, kmer)
+        end
+        i += 1
+    end
+    return nothing
+end
+
+function Base.iterate(it::SpacedKmerIterator{T,S}, state::Tuple{Int,UInt64}) where {T,S<:BioSequence{<:FourBitNucs}}
+    i, kmer = state
+    filled = it.filled
+    i += it.increment
+    while i ≤ it.stop
+        nt = reinterpret(Int8, inbounds_getindex(it.seq, i))
+        if nt == 0xff # ambiguous
+            filled = 0
+        else
+            filled += 1
+            @inbounds val = kmerbits[nt + 1]
+            kmer = kmer << 2 | val
+        end
+        if filled == kmersize(T)
+            pos = i - kmersize(T) + 1
+            return (pos, T(kmer)), (i, kmer)
+        end
+        i += 1
+    end
+    return nothing
 end

--- a/src/kmer.jl
+++ b/src/kmer.jl
@@ -52,14 +52,10 @@ end
 # Conversion
 # ----------
 
-function DNAKmer{K}(x::UInt64) where {K}
+function Kmer{T, K}(x::UInt64) where {T, K}
+    checkkmer(Kmer{T,K})
     mask = ~UInt64(0) >> (64 - 2K)
-    return reinterpret(DNAKmer{K}, x & mask)
-end
-
-function RNAKmer{K}(x::UInt64) where {K}
-    mask = ~UInt64(0) >> (64 - 2K)
-    return reinterpret(RNAKmer{K}, x & mask)
+    return reinterpret(Kmer{T, K}, x & mask)
 end
 
 UInt64(x::Kmer) = reinterpret(UInt64, x)
@@ -157,8 +153,8 @@ function Base.typemax(::Type{Kmer{T,K}}) where {T,K}
 end
 
 @inline function checkkmer(::Type{Kmer{T,K}}) where {T,K}
-    if !(0 ≤ K ≤ 32)
-        throw(ArgumentError("the length K must be within 0..32"))
+    if !(1 ≤ K ≤ 32)
+        throw(ArgumentError("the length K must be within 1..32"))
     end
 end
 

--- a/src/minhash.jl
+++ b/src/minhash.jl
@@ -5,7 +5,6 @@
 #
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
-using DataStructures: SortedSet
 
 """
 MinHash Sketch type

--- a/test/bioseq/gc_content.jl
+++ b/test/bioseq/gc_content.jl
@@ -6,7 +6,6 @@
     @test gc_content(dna"ACATTGTGTATAACAAAAGG") === 6 / 20
     @test gc_content(dna"GAGGCGTTTATCATC"[2:end]) === 6 / 14
 
-    @test gc_content(DNAKmer("")) === 0.0
     @test gc_content(DNAKmer("AATA")) === 0.0
     @test gc_content(DNAKmer("ACGT")) === 0.5
     @test gc_content(DNAKmer("CGGC")) === 1.0
@@ -19,7 +18,6 @@
     @test gc_content(rna"ACAUUGUGUAUAACAAAAGG") === 6 / 20
     @test gc_content(rna"GAGGCGUUUAUCAUC"[2:end]) === 6 / 14
 
-    @test gc_content(RNAKmer("")) === 0.0
     @test gc_content(RNAKmer("AAUA")) === 0.0
     @test gc_content(RNAKmer("ACGU")) === 0.5
     @test gc_content(RNAKmer("CGGC")) === 1.0

--- a/test/bioseq/transformations.jl
+++ b/test/bioseq/transformations.jl
@@ -45,6 +45,13 @@
             test_dna_complement(DNAAlphabet{2}, random_dna(len, probs))
             test_rna_complement(RNAAlphabet{2}, random_rna(len, probs))
         end
+        seq_string = join(rand("-ACGTSWKMYRBDHVN", 1000))
+        seq = complement(BioSequence{DNAAlphabet{4}}(seq_string))
+        @test String(seq) == dna_complement(seq_string)
+
+        seq_string = join(rand("-ACGUSWKMYRBDHVN", 1000))
+        seq = complement(BioSequence{RNAAlphabet{4}}(seq_string))
+        @test String(seq) == rna_complement(seq_string)
     end
 
     @testset "Reverse complement" begin
@@ -56,6 +63,13 @@
             test_dna_revcomp(DNAAlphabet{2}, random_dna(len, probs))
             test_rna_revcomp(RNAAlphabet{2}, random_rna(len, probs))
         end
+        seq_string = join(rand("-ACGTSWKMYRBDHVN", 1000))
+        seq = reverse_complement(BioSequence{DNAAlphabet{4}}(seq_string))
+        @test String(seq) == reverse(dna_complement(seq_string))
+
+        seq_string = join(rand("-ACGUSWKMYRBDHVN", 1000))
+        seq = reverse_complement(BioSequence{RNAAlphabet{4}}(seq_string))
+        @test String(seq) == reverse(rna_complement(seq_string))
     end
 
     @testset "Map" begin

--- a/test/kmers/access.jl
+++ b/test/kmers/access.jl
@@ -19,12 +19,10 @@
 
     @testset "Iteration through DNA Kmer" begin
         @test iterate(DNAKmer("ACTG")) == (DNA_A, 2)
-        @test iterate(DNAKmer(""))     === nothing
 
         @test iterate(DNAKmer("ACTG"), 1) == (DNA_A, 2)
         @test iterate(DNAKmer("ACTG"), 4) == (DNA_G, 5)
 
-        @test iterate(DNAKmer(""), 1)      === nothing
         @test iterate(DNAKmer("ACTG"), 1)  !== nothing
         @test iterate(DNAKmer("ACTG"), 4)  !== nothing
         @test iterate(DNAKmer("ACTG"), 5)  === nothing
@@ -51,12 +49,10 @@
 
     @testset "Iteration through RNA Kmer" begin
         @test iterate(RNAKmer("ACUG")) == (RNA_A, 2)
-        @test iterate(RNAKmer("")) === nothing
 
         @test iterate(RNAKmer("ACUG"), 1) == (RNA_A, 2)
         @test iterate(RNAKmer("ACUG"), 4) == (RNA_G, 5)
 
-        @test iterate(RNAKmer(""), 1)      === nothing
         @test iterate(RNAKmer("ACUG"), 1)  !== nothing
         @test iterate(RNAKmer("ACUG"), 4)  !== nothing
         @test iterate(RNAKmer("ACUG"), 5)  === nothing

--- a/test/kmers/arithmetic.jl
+++ b/test/kmers/arithmetic.jl
@@ -16,20 +16,20 @@
     end
 
     @testset "typemin" begin
-        for k in 0:32
+        for k in 1:32
             @test typemin(DNAKmer{k}) === DNAKmer("A"^k)
             @test typemin(RNAKmer{k}) === RNAKmer("A"^k)
         end
-        @test_throws ArgumentError typemin(DNAKmer{-1})
+        @test_throws ArgumentError typemin(DNAKmer{0})
         @test_throws ArgumentError typemin(DNAKmer{33})
     end
 
     @testset "typemax" begin
-        for k in 0:32
+        for k in 1:32
             @test typemax(DNAKmer{k}) === DNAKmer("T"^k)
             @test typemax(RNAKmer{k}) === RNAKmer("U"^k)
         end
-        @test_throws ArgumentError typemax(DNAKmer{-1})
+        @test_throws ArgumentError typemax(DNAKmer{0})
         @test_throws ArgumentError typemax(DNAKmer{33})
     end
 end

--- a/test/kmers/conversion.jl
+++ b/test/kmers/conversion.jl
@@ -47,7 +47,7 @@ global reps = 10
         return String(BioSequence{A}(Kmer(BioSequence{A}(seq)))) == uppercase(seq)
     end
 
-    for len in [0, 1, 16, 32]
+    for len in [1, 16, 32]
         # UInt64 conversions
         @test all(Bool[check_uint64_convertion(DNA, rand(UInt64(0):UInt64(UInt64(1) << 2len - 1)), len) for _ in 1:reps])
         @test all(Bool[check_uint64_convertion(RNA, rand(UInt64(0):UInt64(UInt64(1) << 2len - 1)), len) for _ in 1:reps])
@@ -65,10 +65,8 @@ global reps = 10
         @test all(Bool[check_biosequence_construction(RNASequence(random_rna_kmer(len))) for _ in 1:reps])
 
         # Construction from nucleotide arrays
-        if len > 0
-            @test all(Bool[check_nucarray_kmer(random_dna_kmer_nucleotides(len)) for _ in 1:reps])
-            @test all(Bool[check_nucarray_kmer(random_rna_kmer_nucleotides(len)) for _ in 1:reps])
-        end
+        @test all(Bool[check_nucarray_kmer(random_dna_kmer_nucleotides(len)) for _ in 1:reps])
+        @test all(Bool[check_nucarray_kmer(random_rna_kmer_nucleotides(len)) for _ in 1:reps])
 
         # Roundabout conversions
         @test all(Bool[check_roundabout_construction(DNAAlphabet{2}, random_dna_kmer(len)) for _ in 1:reps])
@@ -78,6 +76,9 @@ global reps = 10
     end
 
     @test_throws Exception Kmer() # can't construct 0-mer using `Kmer()`
+    @test_throws Exception Kmer(dna"") # 0-mers not allowed
+    @test_throws Exception DNAKmer{0}(UInt64(0)) # 0-mers not allowed
+    @test_throws Exception RNAKmer{0}(UInt64(0)) # 0-mers not allowed
     @test_throws Exception Kmer(RNA_A, RNA_C, RNA_G, RNA_N, RNA_U) # no Ns in kmers
     @test_throws Exception Kmer(DNA_A, DNA_C, DNA_G, DNA_N, DNA_T) # no Ns in kmers
     @test_throws Exception Kmer(rna"ACGNU")# no Ns in kmers

--- a/test/kmers/eachkmer.jl
+++ b/test/kmers/eachkmer.jl
@@ -17,22 +17,32 @@
         ys = [convert(String, x)
               for (i, x) in collect(eachkmer(S(seq), k, step))]
         zs = string_eachkmer(seq, k, step)
+
         @test xs == ys == zs
     end
 
-    for k in [0, 1, 3, 16, 32], step in 1:3, len in [1, 2, 3, 5, 10, 100, 1000]
+    function test_iteratorlength(S, seq::AbstractString, k, step)
+         @test length(eachkmer(S(seq), k, step)) == length(string_eachkmer(seq, k, step))
+    end
+
+    for k in [1, 3, 16, 32], step in 1:3, len in [1, 2, 3, 5, 10, 100, 1000]
         test_eachkmer(BioSequence{DNAAlphabet{4}}, random_dna(len), k, step)
         test_eachkmer(BioSequence{RNAAlphabet{4}}, random_rna(len), k, step)
         test_eachkmer(ReferenceSequence, random_dna(len), k, step)
 
         probs = [0.25, 0.25, 0.25, 0.25, 0.00]
+
         test_eachkmer(BioSequence{DNAAlphabet{2}}, random_dna(len, probs), k, step)
         test_eachkmer(BioSequence{RNAAlphabet{2}}, random_rna(len, probs), k, step)
+
+        test_iteratorlength(BioSequence{DNAAlphabet{2}}, random_dna(len, probs), k, step)
+        test_iteratorlength(BioSequence{RNAAlphabet{2}}, random_rna(len, probs), k, step)
     end
 
     @test isempty(collect(each(DNAKmer{1}, dna"")))
     @test isempty(collect(each(DNAKmer{1}, dna"NNNNNNNNNN")))
     @test_throws Exception each(DNAKmer{-1}, dna"ACGT")
+    @test_throws Exception each(DNAKmer{0}, dna"ACGT")
     @test_throws Exception each(DNAKmer{33}, dna"ACGT")
     @test collect(each(DNAKmer{3}, dna"AC-TGAG--TGC")) == [(4, DNACodon(DNA_T, DNA_G, DNA_A)),
                                                            (5, DNACodon(DNA_G, DNA_A, DNA_G)),

--- a/test/kmers/length.jl
+++ b/test/kmers/length.jl
@@ -1,5 +1,5 @@
 @testset "Length" begin
-    for len in [0, 1, 16, 32]
+    for len in [1, 16, 32]
         @test length(DNAKmer(random_dna_kmer(len))) == len
         @test length(RNAKmer(random_rna_kmer(len))) == len
     end

--- a/test/kmers/mismatches.jl
+++ b/test/kmers/mismatches.jl
@@ -7,7 +7,7 @@
         @test mismatches(a, b) === mismatches(b, a) === count
     end
 
-    for len in 0:32, _ in 1:10
+    for len in 1:32, _ in 1:10
         a = random_dna_kmer(len)
         b = random_dna_kmer(len)
         test_mismatches(DNAKmer(a), DNAKmer(b))

--- a/test/kmers/print.jl
+++ b/test/kmers/print.jl
@@ -1,9 +1,6 @@
 @testset "Print" begin
     buf = IOBuffer()
 
-    print(buf, DNAKmer(""))
-    @test String(take!(buf)) == ""
-
     print(buf, DNAKmer("ACGT"))
     @test String(take!(buf)) == "ACGT"
 
@@ -13,9 +10,6 @@ end
 
 @testset "Show" begin
     buf = IOBuffer()
-
-    show(buf, DNAKmer(""))
-    @test String(take!(buf)) == "< EMPTY SEQUENCE >"
 
     show(buf, DNAKmer("AGAGT"))
     @test String(take!(buf)) == "AGAGT"

--- a/test/kmers/random.jl
+++ b/test/kmers/random.jl
@@ -1,5 +1,5 @@
 @testset "Random" begin
-    @testset for k in 0:32
+    @testset for k in 1:32
         for _ in 1:10
             kmer = rand(DNAKmer{k})
             @test isa(kmer, DNAKmer{k})

--- a/test/kmers/shuffle.jl
+++ b/test/kmers/shuffle.jl
@@ -1,5 +1,5 @@
 @testset "Shuffle" begin
-    for s in ["", "A", "C", "G", "T"]
+    for s in ["A", "C", "G", "T"]
         kmer = DNAKmer(s)
         @test kmer === shuffle(kmer)
     end
@@ -15,7 +15,7 @@
         return a, c, g, t
     end
 
-    for k in 0:32, _ in 1:10
+    for k in 1:32, _ in 1:10
         kmer = rand(DNAKmer{k})
         @test count(kmer) == count(shuffle(kmer))
         if k ≥ 30

--- a/test/kmers/transformations.jl
+++ b/test/kmers/transformations.jl
@@ -25,7 +25,7 @@
     end
 
     @testset "Reverse" begin
-        for len in 0:32, _ in 1:10
+        for len in 1:32, _ in 1:10
             test_reverse(DNA, random_dna_kmer(len))
             test_reverse(RNA, random_rna_kmer(len))
         end
@@ -35,14 +35,14 @@
     end
 
     @testset "Complement" begin
-        for len in 0:32, _ in 1:10
+        for len in 1:32, _ in 1:10
             test_dna_complement(random_dna_kmer(len))
             test_rna_complement(random_rna_kmer(len))
         end
     end
 
     @testset "Reverse Complement" begin
-        for len in 0:32, _ in 1:10
+        for len in 1:32, _ in 1:10
             test_dna_revcomp(random_dna_kmer(len))
             test_rna_revcomp(random_rna_kmer(len))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,36 +123,18 @@ end
 
 function dna_complement(seq::AbstractString)
     seqc = Vector{Char}(undef, length(seq))
+    complementer = Dict(zip("-ACGTSWYRKMDVHBN", "-TGCASWRYMKHBDVN"))
     for (i, c) in enumerate(seq)
-        if c     ==   'A'
-            seqc[i] = 'T'
-        elseif c ==   'C'
-            seqc[i] = 'G'
-        elseif c ==   'G'
-            seqc[i] = 'C'
-        elseif c ==   'T'
-            seqc[i] = 'A'
-        else
-            seqc[i] = seq[i]
-        end
+        seqc[i] = complementer[c]
     end
     return String(seqc)
 end
 
 function rna_complement(seq::AbstractString)
     seqc = Vector{Char}(undef, length(seq))
+    complementer = Dict(zip("-ACGUSWYRKMDVHBN", "-UGCASWRYMKHBDVN"))
     for (i, c) in enumerate(seq)
-        if c == 'A'
-            seqc[i] = 'U'
-        elseif c == 'C'
-            seqc[i] = 'G'
-        elseif c == 'G'
-            seqc[i] = 'C'
-        elseif c == 'U'
-            seqc[i] = 'A'
-        else
-            seqc[i] = seq[i]
-        end
+        seqc[i] = complementer[c]
     end
     return String(seqc)
 end


### PR DESCRIPTION
# Type specialization for faster kmer iteration and misc changes

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [:heavy_check_mark: ] :sparkles: New feature (A non-breaking change which adds functionality).
* [ :heavy_check_mark:] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ :heavy_check_mark:] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

This pull requests has a variety of changes:

### Improved Kmer iteration speed

As discussed in [Issue 46](https://github.com/BioJulia/BioSequences.jl/issues/46), the previous implementation of `iterate` on `EachKmerIterator` was general, and did not specialize for the special cases of two-bit nucletide sequences, nor for cases where the iterator's `step` was 1.

Here, I have added three new types:
`AbstractKmerIterator`
`EveryKmerIterator <: AbstractKmerIterator`, for step == 1
`SpacedKmerIterator <: AbstractKmerIterator`, for step != 1

and removed the old `EachKmerIterator` type. Further, I have added a `length` method for 2-bit nucleotide kmer iterators, since their length can be known beforehand.


**Note**: It might be useful for the `each` function to take start and stop keywords, I have not added them in order to not change the interface.

**Justification**
Many bioinformatics workflows rely on kmers, precisely because they are fast. By changing the iteration protocol to improve speeds, many current and potential downstream applications of kmers such as kmer composition analysis or kmer distribution will be significantly sped up.

**Benchmark**
The performance difference depends on several factors: Sequence type, value of K, value of `step` and sequence length. 

In general, the speed relative to the current implementation is 4.5x in the typical case, 1.2x in the worst case and 27x in the best case.

In order to benchmark, I've used this simple function:
```
function bm(x)
    n = 0
    for i in x
        n += 1
    end
    return n
end
```

With the following results:
Before:
```
Len: 100    Bit: 2  K: 4    Step: 1    772.761 ns (0 allocations: 0 bytes)
Len: 100    Bit: 2  K: 4    Step: 4    323.026 ns (0 allocations: 0 bytes)
Len: 100    Bit: 2  K: 30   Step: 1    639.707 ns (0 allocations: 0 bytes)
Len: 100    Bit: 2  K: 30   Step: 4    317.760 ns (0 allocations: 0 bytes)
Len: 100    Bit: 4  K: 4    Step: 1    659.629 ns (0 allocations: 0 bytes)
Len: 100    Bit: 4  K: 4    Step: 4    280.278 ns (0 allocations: 0 bytes)
Len: 100    Bit: 4  K: 30   Step: 1    607.361 ns (0 allocations: 0 bytes)
Len: 100    Bit: 4  K: 30   Step: 4    276.466 ns (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 4    Step: 1    776.198 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 4    Step: 4    313.785 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 4    Step: 100   12.514 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 30   Step: 1    781.717 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 30   Step: 4    349.243 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 30   Step: 100   62.372 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 4    Step: 1    659.685 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 4    Step: 4    266.367 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 4    Step: 100   10.692 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 30   Step: 1    759.375 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 30   Step: 4    310.910 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 30   Step: 100   50.230 μs (0 allocations: 0 bytes)
```
After
```
Len: 100    Bit: 2  K: 4    Step: 1    57.360 ns (0 allocations: 0 bytes)
Len: 100    Bit: 2  K: 4    Step: 4    62.466 ns (0 allocations: 0 bytes)
Len: 100    Bit: 2  K: 30   Step: 1    55.463 ns (0 allocations: 0 bytes)
Len: 100    Bit: 2  K: 30   Step: 4    70.036 ns (0 allocations: 0 bytes)
Len: 100    Bit: 4  K: 4    Step: 1   151.853 ns (0 allocations: 0 bytes)
Len: 100    Bit: 4  K: 4    Step: 4   131.818 ns (0 allocations: 0 bytes)
Len: 100    Bit: 4  K: 30   Step: 1   148.653 ns (0 allocations: 0 bytes)
Len: 100    Bit: 4  K: 30   Step: 4   123.503 ns (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 4    Step: 1    28.718 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 4    Step: 4    35.829 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 4    Step: 100   1.460 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 30   Step: 1    28.694 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 30   Step: 4    42.997 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 2  K: 30   Step: 100  18.374 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 4    Step: 1   143.237 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 4    Step: 4   121.794 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 4    Step: 100   4.979 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 30   Step: 1   143.241 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 30   Step: 4   121.809 μs (0 allocations: 0 bytes)
Len: 100000 Bit: 4  K: 30   Step: 100  35.020 μs (0 allocations: 0 bytes)
```

### Disallow instantiation of zero-mers and negative kmers
__This change is breaking__

Previously, kmers with K of 0 or negative numbers could be instantiated. With these changes, attempting to do so throws an ArgumentError.
The rationale is both that zero or negative kmers make no sense biologically and thus should not be used, and also that they present as edge cases which complicates the code and leads to unexpected errors.

### Remove unused dependency DataStructures
Previously, DataStructures was listed as a dependency and imported in `minhash.jl` but not actually used in any code. I have simply removed DataStructures from `REQUIRE` and `minhash.jl`. This has no effect on the code.

### Change documentation and testing for reverse complementation
On the existing master branch, the documentation for `reverse_complements` states it leaves ambiguous nucleotides as-is, while in actuality, the existing code handles ambiguous nucleotides correctly. Also, the correct complementation and reverse-complementation of ambiguous nucleotides other than N are not tested for. I have amended the documentation and added test cases for ambiguous nucleotides.

### Minor speed increase in Composition for K > 8
Kmer Composition now increments its Dict more effectively resulting in a small speed increase. Other than the modest increase in speed, this is an inconsequential single-line change.


## :ballot_box_with_check: Checklist

- [:heavy_check_mark: ] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [ :heavy_check_mark:] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [:heavy_check_mark: ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [:heavy_check_mark: ] :ok: There are unit tests that cover the code changes I have made.
- [:heavy_check_mark: ] :ok: The unit tests cover my code changes AND they pass.
- [:heavy_check_mark: ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [:heavy_check_mark: ] :ok: All changes should be compatible with the latest stable version of Julia.
- [:heavy_check_mark: ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
