### PR TITLE
Reworked random LongSequence generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New subtypes of Random.Sampler, SamplerUniform and SamplerWeighted.
+- Random `LongSequence`s can now be created with `randseq`,
+  optionally using a sampler to specify element distribution.
+- All random `LongSequence` generator methods take an optional AbstractRNG argument.
+- Add methods to `randseq` to optimize random generation of `NucleicAcid` or `AminoAcid` `LongSequence`s.
+
 ### Changed
 - The abstract `Sequence` type is now called `BioSequence{A}`.
 - The type previously called `BioSequence{A}` is now `LongSequence{A}`.
@@ -49,7 +56,7 @@ is less than or equal to zero.
 ### Added
 - Position weight matrix search functionality.
 - A generalised composition method.
-- `typemin` and `typemax` methods for `Kmer` types. 
+- `typemin` and `typemax` methods for `Kmer` types.
 
 ### Changed
 - `MinHash` function now generalised to `Reader` types.
@@ -57,7 +64,7 @@ is less than or equal to zero.
 
 ## [0.7.0] - 2017-07-28
 ### Added
-- Support for julia v0.6 only. 
+- Support for julia v0.6 only.
 
 ### Removed
 - :exclamation: Dropped support for julia v0.5.

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -85,7 +85,7 @@ export
     AA_X,
     AA_Term,
     AA_Gap,
-    
+
     # BioSequences
     BioSequence,
     LongSequence,
@@ -124,7 +124,9 @@ export
     isrepetitive,
     ambiguous_positions,
     gc_content,
-    SequenceGenerator,
+    SamplerUniform,
+    SamplerWeighted,
+    randseq,
     randdnaseq,
     randrnaseq,
     randaaseq,

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -19,7 +19,7 @@ LongSequence(::Type{AminoAcid}) = AminoAcidSequence()
 LongSequence(::Type{Char}) = CharSequence()
 
 function LongSequence()
-    return LongSequence{VoidAlphabet}(Vector{UInt64}(0), 0:-1, false)
+    return LongSequence{VoidAlphabet}(Vector{UInt64}(), 0:-1, false)
 end
 
 function LongSequence{A}(
@@ -56,7 +56,7 @@ for (alpha, alphb) in [(DNAAlphabet{4}, DNAAlphabet{2}), # DNA to DNA
                        (DNAAlphabet{4}, RNAAlphabet{2}),
                        (RNAAlphabet{4}, DNAAlphabet{2}), # RNA to DNA
                        (RNAAlphabet{2}, DNAAlphabet{4})]
-    
+
     @eval function (::Type{LongSequence{$alpha}})(seq::LongSequence{$alphb})
         newseq = LongSequence{$alpha}(length(seq))
         for (i, x) in enumerate(seq)
@@ -70,7 +70,7 @@ for (alpha, alphb) in [(DNAAlphabet{2}, RNAAlphabet{2}),
                        (RNAAlphabet{2}, DNAAlphabet{2}),
                        (DNAAlphabet{4}, RNAAlphabet{4}),
                        (RNAAlphabet{4}, DNAAlphabet{4})]
-    
+
     @eval function (::Type{LongSequence{$alpha}})(seq::LongSequence{$alphb})
         newseq = LongSequence{$alpha}(seq.data, seq.part, true)
         seq.shared = true

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -7,6 +7,9 @@
 # License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
 function LongSequence{A}(len::Integer) where {A<:Alphabet}
+    if len < 0
+        throw(ArgumentError("len must be non-negative"))
+    end
     return LongSequence{A}(Vector{UInt64}(undef, seq_data_len(A, len)), 1:convert(Int, len), false)
 end
 

--- a/src/longsequences/randseq.jl
+++ b/src/longsequences/randseq.jl
@@ -4,87 +4,193 @@
 # Random sequence generator.
 #
 # This file is a part of BioJulia.
-# License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
+# License is MIT: https://github.com/BioJulia/LongSequences.jl/blob/master/LICENSE.md
+
+# TODO: Add length check in instantiator of LongSequence
+
+import Random: Sampler
 
 """
-Abstract sequence generator type.
-"""
-abstract type SequenceGenerator{T} end
+    SamplerUniform{T}
 
-# Sequence generator of stationary distributions.
-struct StationaryGenerator{T} <: SequenceGenerator{T}
+Uniform sampler of type T. Instantiate with a an iterable collection of eltype T
+containing the desired elements.
+
+# Examples
+```
+julia> sp = SamplerUniform{RNA}(rna"ACGU")
+```
+"""
+struct SamplerUniform{T} <: Sampler{T}
+    elems::Vector{T}
+    len::Int
+
+    function SamplerUniform{T}(elems) where {T}
+        elemsvector = convert(Vector{T}, collect(elems))
+        return new(elemsvector, length(elemsvector))
+    end
+end
+
+"""
+    SamplerWeighted{T}
+
+Weighted sampler of type T. Instantiate with a Vector{T} containing the desired
+elements of type T, and a Vector{Float64} containing the probability to generate
+each element except the last. The last probability is the remaining probability
+up to 1.
+
+# Examples
+```
+julia> sp = SamplerWeighted{RNA}(rna"ACGUN", fill(0.2475, 4))
+```
+"""
+struct SamplerWeighted{T} <: Sampler{T}
     elems::Vector{T}
     probs::Vector{Float64}
 
-    function StationaryGenerator{T}(elems, probs) where {T}
-        @assert sum(probs) ≤ 1
-        @assert length(elems) == length(probs) + 1
-        return new(copy(elems), copy(probs))
-    end
-end
-
-function StationaryGenerator(elems::AbstractVector{T},
-                             probs::AbstractVector{<:AbstractFloat}) where {T}
-    return StationaryGenerator{T}(elems, probs)
-end
-
-alphatype(::Type{DNA}) = DNAAlphabet{4}
-alphatype(::Type{RNA}) = RNAAlphabet{4}
-alphatype(::Type{AminoAcid}) = AminoAcidAlphabet
-
-function randseq(generator::StationaryGenerator{T}, len::Integer) where {T}
-    if len < 0
-        throw(ArgumentError("length must be non-negative"))
-    end
-    seq = LongSequence{alphatype(T)}(len)
-    probs = generator.probs
-    for i in 1:len
-        r = rand()
-        j = 1
-        cumprob = probs[j]
-        while cumprob < r && j ≤ lastindex(probs)
-            j += 1
-            if j ≤ lastindex(probs)
-                cumprob += probs[j]
-            end
+    function SamplerWeighted{T}(elems, probs) where {T}
+        probsum = sum(probs)
+        if probsum ≥ 1.0
+            throw(ArgumentError("sum of probabilties cannot exceed 1.0"))
+        elseif length(elems) != length(probs) + 1
+            throw(ArgumentError("length of elems must be length of probs + 1"))
+        elseif minimum(probs) < 0.0
+            throw(ArgumentError("probabilities must be non-negative"))
         end
-        seq[i] = generator.elems[j]
+        # Even with float weirdness,  we can guarantee x + (1.0 - x) == 1.0,
+        # when 0 ≤ x ≤ 1, as there's no exponent, and it works like int addition
+        elemsvector = convert(Vector{T}, collect(elems))
+        probsvector = push!(convert(Vector{Float64}, collect(probs)), 1.0 - probsum)
+        return new(elemsvector, probsvector)
+    end
+end
+
+Base.eltype(::Type{SamplerWeighted{T}}) where {T} = T
+Base.eltype(::Type{SamplerUniform{T}}) where {T} = T
+
+function Base.rand(rng::AbstractRNG, sp::SamplerWeighted)
+    probs = sp.probs
+    r = rand(rng)
+    j = 1
+    @inbounds cumulative_prob = probs[j]
+    while cumulative_prob < r
+        j += 1
+        @inbounds cumulative_prob += probs[j]
+    end
+    return @inbounds sp.elems[j]
+end
+
+function Base.rand(rng::AbstractRNG, sp::SamplerUniform)
+    return @inbounds sp.elems[rand(1:sp.len)]
+end
+
+const DefaultAASampler = SamplerUniform{AminoAcid}(aa"ACDEFGHIKLMNPQRSTVWY")
+
+"""
+    randseq{A::Alphabet, sp::SamplerWeighted{T}, len::Integer)
+
+Generate a LongSequence{A} of length `len` with elements drawn from
+the given sampler.
+
+# Example:
+```
+# Generate 1000-length RNA with 4% chance of N, 24% for A, C, G, or U
+julia> sp = SamplerWeighted{RNA}(rna"ACGUN", fill(0.24, 4))
+julia> seq = randseq(RNAAlphabet{4}(), sp, 50)
+50nt RNA Sequence:
+CUNGGGCCCGGGNAAACGUGGUACACCCUGUUAAUAUCAACNNGCGCUNU
+```
+"""
+function randseq(A::Alphabet, sp::Sampler, len::Integer)
+    seq = LongSequence{typeof(A)}(len)
+    @inbounds for i in 1:len
+        letter = rand(sp)
+        unsafe_setindex!(seq, letter, i)
     end
     return seq
 end
 
-const StationaryDNAGenerator = StationaryGenerator(
-    collect(dna"ACGT"), ones(3) / 4)
+"""
+    randseq{A::Alphabet, len::Integer}
 
-const StationaryRNAGenerator = StationaryGenerator(
-    collect(rna"ACGU"), ones(3) / 4)
+Generate a LongSequence{A} of length `len` from the specified alphabet, drawn
+from the default distribution. User-defined alphabets should implement this
+method to implement random LongSequence generation.
 
-const StationaryAAGenerator = StationaryGenerator(
-    collect(aa"ARNDCQEGHILKMFPSTWYV"), ones(19) / 20)
+For RNA and DNA alphabets, the default distribution is uniform across A, C, G,
+and T/U.
+For AminoAcidAlphabet, it is uniform across the 20 proteogenic amino acids.
+For a user-defined alphabet A, default is uniform across all elements of
+alphabet(eltype(A)).
+
+# Example:
+```
+julia> seq = randseq(AminoAcidAlphabet(), 50)
+50aa Amino Acid Sequence:
+VFMHSIRMIRLMVHRSWKMHSARHVNFIRCQDKKWKSADGIYTDICKYSM
+```
+"""
+function randseq(A::NucleicAcidAlphabet{2}, len::Integer)
+    vector = rand(UInt64, seq_data_len(typeof(A), len))
+    return LongSequence{typeof(A)}(vector, 1:len, false)
+end
+
+# Fast specialization for four-bit nucleotides
+function randseq(A::NucleicAcidAlphabet{4}, len::Integer)
+    seq = LongSequence{typeof(A)}(len)
+    randombits = zero(UInt64)
+    # Generate random bases for each of the UInt64 in the .data field:
+    for i in 1:seq_data_len(typeof(A), len)
+        x = zero(UInt64)
+        # 64 bits of randomness is enough for 2x16 4-bit nucleotides
+        if isodd(i)
+            randombits = rand(UInt64)
+        end
+        # Fill each of the 16 bases in the UInt64
+        for nucleotide in 1:16
+            # This is the position of the set bit of the four encoding the base
+            bitposition = (randombits & 3) + 1
+            x <<= bitposition
+            x |= UInt64(1)
+            x <<= 4 - bitposition
+            randombits >>>= 2
+        end
+        @inbounds seq.data[i] = x
+    end
+    return seq
+end
+
+function randseq(::AminoAcidAlphabet, len::Integer)
+    return randseq(AminoAcidAlphabet(), DefaultAASampler, len)
+end
+
+# Generic fallback for user-defined Alphabets.
+function randseq(A::Alphabet, len::Integer)
+    letters = symbols(A)
+    sampler = SamplerUniform{eltype(A)}(letters)
+    return randseq(A, sampler, len)
+end
 
 """
     randdnaseq(len::Integer)
 
-Generate a random DNA sequence of length `len`.
+Generate a random LongSequence{DNAAlphabet{4}} sequence of length `len`,
+with bases drawn uniformly from [A, C, G, T]
 """
-function randdnaseq(len::Integer)
-    return randseq(StationaryDNAGenerator, len)
-end
+randdnaseq(len::Integer) = randseq(DNAAlphabet{4}(), len)
 
 """
     randrnaseq(len::Integer)
 
-Generate a random RNA sequence of length `len`.
+Generate a random LongSequence{RNAAlphabet{4}} sequence of length `len`,
+with bases drawn uniformly from [A, C, G, U]
 """
-function randrnaseq(len::Integer)
-    return randseq(StationaryRNAGenerator, len)
-end
+randrnaseq(len::Integer) = randseq(RNAAlphabet{4}(), len)
 
 """
     randaaseq(len::Integer)
 
-Generate a random amino acid sequence of length `len`.
+Generate a random LongSequence{AminoAcidAlphabet} sequence of length `len`,
+with amino acids drawn uniformly from the 20 proteogenic ones.
 """
-function randaaseq(len::Integer)
-    return randseq(StationaryAAGenerator, len)
-end
+randaaseq(len::Integer) = randseq(AminoAcidAlphabet(), len)

--- a/src/longsequences/randseq.jl
+++ b/src/longsequences/randseq.jl
@@ -181,7 +181,6 @@ function randseq_allbits(rng::AbstractRNG, A::Alphabet, len::Integer)
     vector = rand(rng, UInt64, seq_data_len(typeof(A), len))
     return LongSequence{typeof(A)}(vector, 1:len, false)
 end
-randseq_allbits(A::Alphabet, len::Integer) = randseq_allbits(GLOBAL_RNG, A, len)
 
 """
     randdnaseq([rng::AbstractRNG], len::Integer)

--- a/src/longsequences/randseq.jl
+++ b/src/longsequences/randseq.jl
@@ -6,7 +6,7 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
-import Random: Sampler
+import Random: Sampler, GLOBAL_RNG
 
 """
     SamplerUniform{T}
@@ -24,12 +24,17 @@ struct SamplerUniform{T} <: Sampler{T}
 
     function SamplerUniform{T}(elems) where {T}
         elemsvector = convert(Vector{T}, collect(elems))
+        if length(elemsvector) < 1
+            throw(ArgumentError("elements collection must be non-empty"))
+        end
         return new(elemsvector)
     end
 end
 
 SamplerUniform(elems) = SamplerUniform{eltype(elems)}(elems)
-Base.rand(rng::AbstractRNG, sp::SamplerUniform) = rand(sp.elems)
+Base.eltype(::Type{SamplerUniform{T}}) where {T} = T
+Base.rand(rng::AbstractRNG, sp::SamplerUniform) = rand(rng, sp.elems)
+Base.rand(sp::SamplerUniform) = rand(GLOBAL_RNG, sp.elems)
 const DefaultAASampler = SamplerUniform(aa"ACDEFGHIKLMNPQRSTVWY")
 
 """
@@ -50,26 +55,29 @@ struct SamplerWeighted{T} <: Sampler{T}
     probs::Vector{Float64}
 
     function SamplerWeighted{T}(elems, probs) where {T}
-        probsum = sum(probs)
-        if probsum ≥ 1.0
-            throw(ArgumentError("sum of probabilties cannot exceed 1.0"))
-        elseif length(elems) != length(probs) + 1
+        elemsvector = convert(Vector{T}, collect(elems))
+        probsvector = convert(Vector{Float64}, collect(probs))
+        if !isempty(probsvector)
+            probsum = sum(probsvector)
+            if probsum > 1.0
+                throw(ArgumentError("sum of probabilties cannot exceed 1.0"))
+            elseif minimum(probsvector) < 0.0
+                throw(ArgumentError("probabilities must be non-negative"))
+            end
+        else
+            probsum = 0.0
+        end
+        if length(elemsvector) != length(probsvector) + 1
             throw(ArgumentError("length of elems must be length of probs + 1"))
-        elseif minimum(probs) < 0.0
-            throw(ArgumentError("probabilities must be non-negative"))
         end
         # Even with float weirdness,  we can guarantee x + (1.0 - x) == 1.0,
         # when 0 ≤ x ≤ 1, as there's no exponent, and it works like int addition
-        elemsvector = convert(Vector{T}, collect(elems))
-        probsvector = push!(convert(Vector{Float64}, collect(probs)), 1.0 - probsum)
-        return new(elemsvector, probsvector)
+        return new(elemsvector, push!(probsvector, 1.0 - probsum))
     end
 end
 
 SamplerWeighted(elems, probs) = SamplerWeighted{eltype(elems)}(elems, probs)
-
 Base.eltype(::Type{SamplerWeighted{T}}) where {T} = T
-Base.eltype(::Type{SamplerUniform{T}}) where {T} = T
 
 function Base.rand(rng::AbstractRNG, sp::SamplerWeighted)
     r = rand(rng)
@@ -81,9 +89,10 @@ function Base.rand(rng::AbstractRNG, sp::SamplerWeighted)
     end
     return @inbounds sp.elems[j]
 end
+Base.rand(sp::SamplerWeighted) = rand(GLOBAL_RNG, sp)
 
 """
-    randseq{A::Alphabet, sp::Sampler, len::Integer)
+    randseq([rng::AbstractRNG], A::Alphabet, sp::Sampler, len::Integer)
 
 Generate a LongSequence{A} of length `len` with elements drawn from
 the given sampler.
@@ -97,17 +106,17 @@ julia> seq = randseq(RNAAlphabet{4}(), sp, 50)
 CUNGGGCCCGGGNAAACGUGGUACACCCUGUUAAUAUCAACNNGCGCUNU
 ```
 """
-function randseq(A::Alphabet, sp::Sampler, len::Integer)
+function randseq(rng::AbstractRNG, A::Alphabet, sp::Sampler, len::Integer)
     seq = LongSequence{typeof(A)}(len)
     @inbounds for i in 1:len
-        letter = rand(sp)
+        letter = rand(rng, sp)
         unsafe_setindex!(seq, letter, i)
     end
     return seq
 end
-
+randseq(A::Alphabet, sp::Sampler, len::Integer) = randseq(GLOBAL_RNG, A, sp, len)
 """
-    randseq{A::Alphabet, len::Integer}
+    randseq([rng::AbstractRNG], A::Alphabet, len::Integer)
 
 Generate a LongSequence{A} of length `len` from the specified alphabet, drawn
 from the default distribution. User-defined alphabets should implement this
@@ -115,7 +124,7 @@ method to implement random LongSequence generation.
 
 For RNA and DNA alphabets, the default distribution is uniform across A, C, G,
 and T/U.
-For AminoAcidAlphabet, it is uniform across the 20 proteogenic amino acids.
+For AminoAcidAlphabet, it is uniform across the 20 standard amino acids.
 For a user-defined alphabet A, default is uniform across all elements of
 `symbols(A)`.
 
@@ -126,7 +135,7 @@ julia> seq = randseq(AminoAcidAlphabet(), 50)
 VFMHSIRMIRLMVHRSWKMHSARHVNFIRCQDKKWKSADGIYTDICKYSM
 ```
 """
-function randseq(A::NucleicAcidAlphabet{4}, len::Integer)
+function randseq(rng::AbstractRNG, A::NucleicAcidAlphabet{4}, len::Integer)
     seq = LongSequence{typeof(A)}(len)
     randombits = zero(UInt64)
     # Generate random bases for each of the UInt64 in the .data field:
@@ -134,7 +143,7 @@ function randseq(A::NucleicAcidAlphabet{4}, len::Integer)
         x = zero(UInt64)
         # 64 bits of randomness is enough for 2x16 4-bit nucleotides
         if isodd(i)
-            randombits = rand(UInt64)
+            randombits = rand(rng, UInt64)
         end
         # Fill each of the 16 bases in the UInt64
         for nucleotide in 1:16
@@ -149,47 +158,54 @@ function randseq(A::NucleicAcidAlphabet{4}, len::Integer)
     end
     return seq
 end
+randseq(A::NucleicAcidAlphabet{4}, len::Integer) = randseq(GLOBAL_RNG, A, len)
 
-function randseq(::AminoAcidAlphabet, len::Integer)
-    return randseq(AminoAcidAlphabet(), DefaultAASampler, len)
+function randseq(rng::AbstractRNG, ::AminoAcidAlphabet, len::Integer)
+    return randseq(rng, AminoAcidAlphabet(), DefaultAASampler, len)
 end
+randseq(A::AminoAcidAlphabet, len::Integer) = randseq(GLOBAL_RNG, A, len)
 
 # Generic fallback method.
-function randseq(A::Alphabet, len::Integer)
+function randseq(rng::AbstractRNG, A::Alphabet, len::Integer)
     if length(A) == 1 << bits_per_symbol(A)
-        return randseq_allbits(A, len)
+        return randseq_allbits(rng, A, len)
     else
         letters = symbols(A)
         sampler = SamplerUniform{eltype(A)}(letters)
-        return randseq(A, sampler, len)
+        return randseq(rng, A, sampler, len)
     end
 end
+randseq(A::Alphabet, len::Integer) = randseq(GLOBAL_RNG, A, len)
 
-function randseq_allbits(A::Alphabet, len::Integer)
-    vector = rand(UInt64, seq_data_len(typeof(A), len))
+function randseq_allbits(rng::AbstractRNG, A::Alphabet, len::Integer)
+    vector = rand(rng, UInt64, seq_data_len(typeof(A), len))
     return LongSequence{typeof(A)}(vector, 1:len, false)
 end
+randseq_allbits(A::Alphabet, len::Integer) = randseq_allbits(GLOBAL_RNG, A, len)
 
 """
-    randdnaseq(len::Integer)
+    randdnaseq([rng::AbstractRNG], len::Integer)
 
 Generate a random LongSequence{DNAAlphabet{4}} sequence of length `len`,
 with bases sampled uniformly from [A, C, G, T]
 """
-randdnaseq(len::Integer) = randseq(DNAAlphabet{4}(), len)
+randdnaseq(rng::AbstractRNG, len::Integer) = randseq(rng, DNAAlphabet{4}(), len)
+randdnaseq(len::Integer) = randseq(GLOBAL_RNG, DNAAlphabet{4}(), len)
 
 """
-    randrnaseq(len::Integer)
+    randrnaseq([rng::AbstractRNG], len::Integer)
 
 Generate a random LongSequence{RNAAlphabet{4}} sequence of length `len`,
 with bases sampled uniformly from [A, C, G, U]
 """
-randrnaseq(len::Integer) = randseq(RNAAlphabet{4}(), len)
+randrnaseq(rng::AbstractRNG, len::Integer) = randseq(rng, RNAAlphabet{4}(), len)
+randrnaseq(len::Integer) = randseq(GLOBAL_RNG, RNAAlphabet{4}(), len)
 
 """
-    randaaseq(len::Integer)
+    randaaseq([rng::AbstractRNG], len::Integer)
 
 Generate a random LongSequence{AminoAcidAlphabet} sequence of length `len`,
 with amino acids sampled uniformly from the 20 standard amino acids.
 """
-randaaseq(len::Integer) = randseq(AminoAcidAlphabet(), len)
+randaaseq(rng::AbstractRNG, len::Integer) = randseq(rng, AminoAcidAlphabet(), len)
+randaaseq(len::Integer) = randseq(GLOBAL_RNG, AminoAcidAlphabet(), len)

--- a/test/longsequences/conversion.jl
+++ b/test/longsequences/conversion.jl
@@ -11,6 +11,12 @@ end
     @test isa(LongSequence{RNAAlphabet{2}}(0), LongSequence)
     @test isa(LongSequence{RNAAlphabet{4}}(10), LongSequence)
     @test isa(LongSequence{AminoAcidAlphabet}(10), LongSequence)
+
+    @test_throws ArgumentError LongSequence{DNAAlphabet{2}}(-1)
+    @test_throws ArgumentError LongSequence{DNAAlphabet{4}}(-1)
+    @test_throws ArgumentError LongSequence{RNAAlphabet{2}}(-1)
+    @test_throws ArgumentError LongSequence{RNAAlphabet{4}}(-1)
+    @test_throws ArgumentError LongSequence{AminoAcidAlphabet}(-1)
 end
 
 @testset "Conversion from/to strings" begin

--- a/test/longsequences/randseq.jl
+++ b/test/longsequences/randseq.jl
@@ -1,0 +1,181 @@
+module t
+
+# Note: This test suite has many hard coded values in it.
+# While that is normally a bad idea, we need to guarantee reproducible results
+# when using the same seed.
+
+global SEED = 0 # Do not change this
+
+function test_sampler(sampler, seed, elements, firstten, T)
+    rng = MersenneTwister(seed)
+    sampled1 = [rand(rng, sampler) for i in 1:1000]
+    sampled2 = rand(MersenneTwister(seed), sampler, 1000)
+    @test sampled1 == sampled2
+    @test Set(sampled1) == Set(T[convert(T, i) for i in elements])
+    @test eltype(sampler) == T
+    @test eltype(firstten) == T
+    @test rand(MersenneTwister(seed), sampler, 10) == firstten
+end
+
+function test_isseq(seq, alphabettype, len)
+    @test seq isa LongSequence{alphabettype}
+    @test length(seq) == len
+end
+
+@testset "SamplerUniform" begin
+    # Cannot instantiate with empty collection
+    @test_throws ArgumentError sampler = SamplerUniform{DNA}(DNA[])
+
+    # DNA sampler with DNA array
+    sampler = SamplerUniform{DNA}([DNA_A, DNA_C, DNA_G, DNA_W])
+    firstten = DNA[DNA_A, DNA_G, DNA_C, DNA_C, DNA_A, DNA_G, DNA_A, DNA_W, DNA_W, DNA_A]
+    test_sampler(sampler, SEED, sampler.elems, firstten, DNA)
+    # Now RNA sampler from DNA array
+    sampler = SamplerUniform{RNA}([DNA_A, DNA_C, DNA_G, DNA_W])
+    firstten = RNA[RNA_A, RNA_G, RNA_C, RNA_C, RNA_A, RNA_G, RNA_A, RNA_W, RNA_W, RNA_A]
+    test_sampler(sampler, SEED, sampler.elems, firstten, RNA)
+
+    # Cannot make AA sampler from DNA
+    @test_throws MethodError s = SamplerUniform{AminoAcid}([DNA_A, DNA_C, DNA_G, DNA_W])
+
+    # Automatically infer eltype
+    sampler1 = SamplerUniform{DNA}([DNA_A, DNA_C])
+    sampler2 = SamplerUniform([DNA_A, DNA_C])
+    @test typeof(sampler2) == SamplerUniform{DNA}
+    @test eltype(sampler1) == eltype(sampler2)
+
+    # Can also infer abstract eltype
+    sampler3 = SamplerUniform([DNA_A, RNA_A])
+    @test eltype(sampler3) == typejoin(DNA, RNA)
+
+    sampler = SamplerUniform{RNA}([DNA_A, DNA_C, DNA_G, DNA_W])
+    @test typeof(rand(sampler)) == RNA
+
+end # SamplerUniform
+
+@testset "SamplerWeighted" begin
+    # Must have one less weight than elements
+    @test_throws ArgumentError SamplerWeighted{DNA}([DNA_A], [0.5])
+    @test_throws ArgumentError SamplerWeighted{DNA}([DNA_A, DNA_C], [0.5, 0.5])
+    @test_throws ArgumentError SamplerWeighted{DNA}([DNA_A], [0.5, 0.5])
+
+    # Weights cannot exceed one
+    @test_throws ArgumentError SamplerWeighted{DNA}([DNA_A, DNA_C], [1.1])
+    @test_throws ArgumentError SamplerWeighted{DNA}([DNA_A, DNA_C, DNA_G], [1.00001, 0.0])
+
+    # Weights cannot be negative
+    @test_throws ArgumentError SamplerWeighted{DNA}([DNA_A, DNA_C, DNA_G], [0.5, -0.001])
+    @test_throws ArgumentError SamplerWeighted{DNA}([DNA_A, DNA_C, DNA_A], [1.1, -0.2])
+
+    # Weights always sum to one after instantiation
+    s = SamplerWeighted{DNA}([DNA_A, DNA_C, DNA_G, DNA_W], [0.03, 0.2, 0.7])
+    @test sum(s.probs) == 1.0
+    s = SamplerWeighted{DNA}([DNA_A], [])
+    @test sum(s.probs) == 1.0
+    s = SamplerWeighted{DNA}([DNA_A, DNA_C], [1.0])
+    @test sum(s.probs) == 1.0
+    s = SamplerWeighted{DNA}([DNA_A, DNA_C, DNA_G], [0.03, 0.20000001])
+    @test sum(s.probs) == 1.0
+
+    sampler = SamplerWeighted{DNA}([DNA_N, DNA_C, DNA_W, DNA_T], [0.1, 0.2, 0.3])
+    firstten = DNA[DNA_T, DNA_T, DNA_C, DNA_C, DNA_C, DNA_C, DNA_N, DNA_N, DNA_W, DNA_T]
+    test_sampler(sampler, 0, sampler.elems, firstten, DNA)
+
+    sampler = SamplerWeighted{RNA}([DNA_N, DNA_C, DNA_W, DNA_T], [0.15, 0.5, 0.2])
+    firstten = RNA[RNA_W, RNA_U, RNA_C, RNA_C, RNA_C, RNA_C, RNA_N, RNA_N, RNA_C, RNA_U]
+    test_sampler(sampler, 0, sampler.elems, firstten, RNA)
+
+    @test_throws MethodError s = SamplerWeighted{AminoAcid}([DNA_A, DNA_C], [0.1])
+
+    # Casual test to see that it can use the global RNG automatically
+    sampler = SamplerWeighted{RNA}([DNA_N, DNA_C, DNA_W, DNA_T], [0.15, 0.5, 0.2])
+    @test typeof(rand(sampler)) == RNA
+
+end # SamplerWeighted
+
+@testset "randseq Sampler" begin
+    # Cannot instantiate < 0-length seq
+    @test_throws ArgumentError randseq(DNAAlphabet{2}(), SamplerUniform(dna"ACG"), -1)
+    @test_throws ArgumentError randseq(AminoAcidAlphabet(), SamplerUniform(aa"VTW"), -1)
+    @test_throws ArgumentError randseq(RNAAlphabet{4}(), SamplerWeighted(dna"ACG", ones(2)/3), -1)
+
+    # CAN make empty sequence with mismatching alphabets
+    # Or with matching alphabets
+    @test randseq(DNAAlphabet{2}(), SamplerUniform(aa"AV"), 0) == LongSequence{DNAAlphabet{2}}()
+    @test randseq(DNAAlphabet{2}(), SamplerUniform(rna"U"), 2) == LongSequence{DNAAlphabet{2}}(dna"TT")
+
+    # Cannot make nonzero sequence with mismatching alphabets
+    @test_throws MethodError randseq(RNAAlphabet{4}(), SamplerUniform(aa"AV", 1))
+    @test_throws MethodError randseq(AminoAcidAlphabet(), SamplerUniform(dna"ACG", 10))
+
+    # A few samplings
+    sampler = SamplerUniform(aa"TVVWYAEDK")
+    @test randseq(MersenneTwister(SEED), AminoAcidAlphabet(), sampler, 10) == aa"TVATTWKDAD"
+
+    sampler = SamplerUniform(dna"TGAWYKN")
+    @test randseq(MersenneTwister(SEED), DNAAlphabet{4}(), sampler, 10) == dna"TAGKTATWTK"
+
+    sampler = SamplerWeighted(rna"UGCMKYN", [0.1, 0.05, 0.2, 0.15, 0.15, 0.2])
+    @test randseq(MersenneTwister(SEED), DNAAlphabet{4}(), sampler, 10) == dna"YNCCCCTTMN"
+
+    # Casual tests to see that it can use the global RNG automatically
+    sampler = SamplerUniform(aa"TVVWYAEDK")
+    seq = randseq(AminoAcidAlphabet(), sampler, 25)
+    test_isseq(seq, AminoAcidAlphabet, 25)
+
+    sampler = SamplerWeighted(rna"UGCMKYN", [0.1, 0.05, 0.2, 0.15, 0.15, 0.2])
+    seq = randseq(RNAAlphabet{4}(), sampler, 25)
+    test_isseq(seq, RNAAlphabet{4}, 25)
+
+    sampler = SamplerUniform(dna"AGC")
+    seq = randseq(DNAAlphabet{2}(), sampler, 25)
+    test_isseq(seq, DNAAlphabet{2}, 25)
+end # randseq Sampler
+
+@testset "randseq" begin
+    sampler = SamplerUniform(aa"ACDEFGHIKLMNPQRSTVWY")
+    automatic = randseq(MersenneTwister(SEED), AminoAcidAlphabet(), 1000)
+    manual = randseq(MersenneTwister(SEED), AminoAcidAlphabet(), sampler, 1000)
+    @test automatic == manual
+    @test Set(automatic) == Set(aa"ACDEFGHIKLMNPQRSTVWY")
+
+    @test randseq(MersenneTwister(SEED), DNAAlphabet{4}(), 20) == dna"AAGATCGGTTCATCCTCAAA"
+    @test randseq(MersenneTwister(SEED), DNAAlphabet{2}(), 20) == dna"TTCGGGATGACTATCTCAGA"
+
+    @test randseq(MersenneTwister(SEED), RNAAlphabet{4}(), 20) == rna"AAGAUCGGUUCAUCCUCAAA"
+    @test randseq(MersenneTwister(SEED), RNAAlphabet{2}(), 20) == rna"UUCGGGAUGACUAUCUCAGA"
+
+    # Casual tests to see that it can use the global RNG automatically
+    seq = randseq(DNAAlphabet{2}(), 100)
+    test_isseq(seq, DNAAlphabet{2}, 100)
+
+    seq = randseq(RNAAlphabet{4}(), 100)
+    test_isseq(seq, RNAAlphabet{4}, 100)
+
+    seq = randseq(AminoAcidAlphabet(), 100)
+    test_isseq(seq, AminoAcidAlphabet, 100)
+end # randseq
+
+@testset "Simple constructors"
+    manual = randseq(MersenneTwister(SEED), AminoAcidAlphabet(), 100)
+    automatic = randaaseq(MersenneTwister(SEED), 100)
+    @test automatic == manual
+
+    manual = randseq(MersenneTwister(SEED), DNAAlphabet{4}(), 100)
+    automatic = randdna(MersenneTwister(SEED), 100)
+    @test automatic == manual
+
+    manual = randseq(MersenneTwister(SEED), RNAAlphabet{4}(), 100)
+    automatic = randrna(MersenneTwister(SEED), 100)
+    @test automatic == manual
+
+    # Casual tests to see that it can use the global RNG automatically
+    seq = randdnaseq(10)
+    test_isseq(seq, DNAAlphabet{4}, 10)
+
+    seq = randrnaseq(10)
+    test_isseq(seq, DNAAlphabet{4}, 100)
+
+    seq = randaaseq(10)
+    test_isseq(seq, AminoAcidAlphabet, 10)
+end # simple constructors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -172,6 +172,7 @@ end
     include("longsequences/counting.jl")
     include("longsequences/gc_content.jl")
     include("longsequences/ambiguous.jl")
+    include("longsequences/randseq.jl")
     include("longsequences/shuffle.jl")
 end
 


### PR DESCRIPTION
# Rework of random LongSequence generation

With BioSequences version2 coming, it's a good time to change any interfaces that could use a change. What follows is a complete rewrite of the random sequence generation - both the internals and the interface. Note that I have not yet written any tests, nor even checked that the current tests pass - please don't merge this until I have. For now, let's just discuss this proposed interface.

## Rationale:
Generating random sequences is a typical step in many bioinformatics workflows. For example, when developing a new method, I will create random DNA sequences from some simple distribution, e.g. 1% N's. The interface presented in this PR allows you to customize sequence generation a bit more, while still keeping the convenient functions like `randomdnaseq`.   

## Types of changes

Complete rewrite of randseq.jl. Furthermore, `LongSequence{A}(len::Integer)` now throws an ArgumentError if `len` < 0, instead of creating a zero-length sequence.

## The new interface

The simplest way to generate sequences is still the functions `randdnaseq`, `randrnaseq` and `randaaseq`. While their internals have changed, their behaviour remains the same.

__Generation sequences from a default distribution: `randseq(A::Alphabet, len::Interger)`__
This is the main method for creation of random LongSequence of a specific alphabet from a default distribution. User-defined alphabets should overwrite this method. Compared the e.g. `randdnaseq`, the advantage of this is that you can more easily and effectively generate for example a `LongSequence{DNAAlphabet{2}}`.

Specialized methods have been implemented for `A::NucleicAcidAlphabet{2}`, `A::NucleicAcidAlphabet{4}` and `AminoAcidAlphabet()`. The default fallback (e.g. for a user-defined alphabet A) is a uniform distribution over all `symbols(A)`.

`randdnaseq`, `randrnaseq` and `randaaseq` calls this method internally.

__Specifying custom distributions__
To do this, the user needs to create either a `SamplerUniform` or a `SamplerWeighted`, both subtypes of `Random.Sampler`. For example:

`julia> sampler = SamplerUniform(dna"ACGTN");`

This sampler can then be queried for random values by `rand(sampler)`. Similarly, for non-uniform distributions, a user might do:

```
julia> sampler = SamplerWeighted(dna"ACGTN", fill(0.2475, 4))
julia> rand(sampler)
DNA_G
```

__Generating sequences from a custom distribution__
To do this, simply pass the sampler to `randseq`:

```
julia> seq = randseq(DNAAlphabet{4}(), sampler, 100)
100nt DNA Sequence:
TGCTCTACAACGGAAACAACCTATAACACATAACTGCTA...GTGTACGGACATATTGANTCATGTGATTAACAGTAGATC
```

## Notes
* I'm not entirely sure I've correctly understood when to use an alphabet type and when to use the singleton instance of it. All methods I've written uses instances.
* Feedback on the interface welcome!

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.