### PR TITLE
Move and generalise sequence transformation methods

### DIFF
--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -88,6 +88,7 @@ export
     
     # BioSequences
     BioSequence,
+    NucleotideSeq,
     LongSequence,
     DNASequence,
     RNASequence,

--- a/src/biosequences/biosequence.jl
+++ b/src/biosequences/biosequence.jl
@@ -65,6 +65,8 @@ Any subtype of `BioSequence` should implement the following methods:
 """
 abstract type BioSequence{A <: Alphabet} end
 
+const NucleotideSeq = BioSequence{<:NucleicAcidAlphabet}
+
 # This is useful for obscure reasons. We use SeqRecord{BioSequence} for reading
 # sequence in an undetermined alphabet, but a consequence that we need to be
 # able to construct a `Sequence`.

--- a/src/biosequences/operations.jl
+++ b/src/biosequences/operations.jl
@@ -21,16 +21,6 @@ function Base.count(f::Function, seq::BioSequence)
     return n
 end
 
-# Transformations
-# ---------------
-
-"Create a copy of a sequence with gap characters removed."
-ungap(seq::BioSequence)  =  filter(x -> x != gap(eltype(seq)), seq)
-
-"Remove gap characters from an input sequence."
-ungap!(seq::BioSequence) = filter!(x -> x != gap(eltype(seq)), seq)
-
-
 # GC content
 # ----------
 

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -151,3 +151,10 @@ Make a reversed complement sequence of `seq`.
 function reverse_complement(seq::NucleotideSeq)
     return complement!(reverse(seq))
 end
+
+# Shuffle
+# -------
+
+function Random.shuffle(seq::BioSequence)
+    return shuffle!(copy(seq))
+end

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -95,3 +95,18 @@ function Base.append!(seq::BioSequence, other::BioSequence)
     copyto!(seq, lastindex(seq) - length(other) + 1, other, 1)
     return seq
 end
+
+"""
+    popfirst!(seq)
+
+Remove the symbol from the beginning of a biological sequence `seq` and return
+it. Returns a variable of `eltype(seq)`.
+"""
+function Base.popfirst!(seq::BioSequence)
+    if isempty(seq)
+        throw(ArgumentError("sequence must be non-empty"))
+    end
+    @inbounds x = seq[1]
+    deleteat!(seq, 1)
+    return x
+end

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -153,10 +153,10 @@ function reverse_complement(seq::NucleotideSeq)
 end
 
 "Create a copy of a sequence with gap characters removed."
-ungap(seq::BioSequence)  =  filter(x -> x != gap(eltype(seq)), seq)
+ungap(seq::BioSequence)  =  filter(!isgap, seq)
 
 "Remove gap characters from an input sequence."
-ungap!(seq::BioSequence) = filter!(x -> x != gap(eltype(seq)), seq)
+ungap!(seq::BioSequence) = filter!(!isgap, seq)
 
 # Shuffle
 # -------

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -123,3 +123,4 @@ end
 
 Base.filter(f::Function, seq::BioSequence) = filter!(f, copy(seq))
 Base.map(f::Function, seq::BioSequence) = map!(f, copy(seq))
+Base.reverse(seq::LongSequence) = reverse!(copy(seq))

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -121,6 +121,5 @@ function Base.pushfirst!(seq::BioSequence, x)
     return seq
 end
 
-function Base.filter(f::Function, seq::BioSequence)
-    return filter!(f, copy(seq))
-end
+Base.filter(f::Function, seq::BioSequence) = filter!(f, copy(seq))
+Base.map(f::Function, seq::BioSequence) = map!(f, copy(seq))

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -6,8 +6,6 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
-
-
 """
     empty!(seq::BioSequence)
 
@@ -109,4 +107,16 @@ function Base.popfirst!(seq::BioSequence)
     @inbounds x = seq[1]
     deleteat!(seq, 1)
     return x
+end
+
+"""
+    pushfirst!(seq, x)
+
+Insert a biological symbol `x` at the beginning of a biological sequence `seq`.
+"""
+function Base.pushfirst!(seq::BioSequence, x)
+    resize!(seq, length(seq) + 1)
+    copyto!(seq, 2, seq, 1, length(seq) - 1)
+    unsafe_setindex!(seq, x, 1)
+    return seq
 end

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -123,7 +123,7 @@ end
 
 Base.filter(f::Function, seq::BioSequence) = filter!(f, copy(seq))
 Base.map(f::Function, seq::BioSequence) = map!(f, copy(seq))
-Base.reverse(seq::LongSequence) = reverse!(copy(seq))
+Base.reverse(seq::BioSequence) = reverse!(copy(seq))
 
 """
     complement(seq)

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -1,0 +1,16 @@
+# Transformations 
+# ===============
+#
+# Methods that manipulate and change a biological sequence.
+#
+# This file is a part of BioJulia.
+# License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
+
+
+
+"""
+    empty!(seq)
+
+Completely empty a biological sequence `seq` of nucleotides.
+"""
+Base.empty!(seq::BioSequence) = resize!(seq, 0)

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -22,7 +22,7 @@ Append a biological symbol `x` to a biological sequence `seq`.
 """
 function Base.push!(seq::BioSequence, x)
     if eltype(seq) !== typeof(x)
-        throw(ArgumentError("Can't push a $(typeof(x)) onto a sequence of $(eltype(seq))"))
+        throw(ArgumentError(string("Can't push a ", typeof(x), " onto a ", eltype(seq), " sequence.")))
     end
     resize!(seq, length(seq) + 1)
     unsafe_setindex!(seq, x, lastindex(seq))
@@ -42,4 +42,21 @@ function Base.pop!(seq::BioSequence)
     @inbounds x = seq[end]
     deleteat!(seq, lastindex(seq))
     return x
+end
+
+"""
+    insert!(seq, i, x)
+
+Insert a biological symbol `x` into a biological sequence `seq`, at the given
+index `i`.
+"""
+function Base.insert!(seq::BioSequence, i::Integer, x)
+    if eltype(seq) !== typeof(x)
+        throw(ArgumentError(string("Can't insert a ", typeof(x), " into a ", eltype(seq), " sequence.")))
+    end
+    checkbounds(seq, i)
+    resize!(seq, length(seq) + 1)
+    copyto!(seq, i + 1, seq, i, lastindex(seq) - i)
+    unsafe_setindex!(seq, x, i)
+    return seq
 end

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -21,9 +21,6 @@ Base.empty!(seq::BioSequence) = resize!(seq, 0)
 Append a biological symbol `x` to a biological sequence `seq`.
 """
 function Base.push!(seq::BioSequence, x)
-    if eltype(seq) !== typeof(x)
-        throw(ArgumentError(string("Can't push a ", typeof(x), " onto a ", eltype(seq), " sequence.")))
-    end
     resize!(seq, length(seq) + 1)
     unsafe_setindex!(seq, x, lastindex(seq))
     return seq
@@ -51,9 +48,6 @@ Insert a biological symbol `x` into a biological sequence `seq`, at the given
 index `i`.
 """
 function Base.insert!(seq::BioSequence, i::Integer, x)
-    if eltype(seq) !== typeof(x)
-        throw(ArgumentError(string("Can't insert a ", typeof(x), " into a ", eltype(seq), " sequence.")))
-    end
     checkbounds(seq, i)
     resize!(seq, length(seq) + 1)
     copyto!(seq, i + 1, seq, i, lastindex(seq) - i)
@@ -87,5 +81,17 @@ function Base.deleteat!(seq::BioSequence, i::Integer)
     checkbounds(seq, i)
     copyto!(seq, i, seq, i + 1, length(seq) - i)
     resize!(seq, length(seq) - 1)
+    return seq
+end
+
+"""
+    append!(seq, other)
+
+Add a biological sequence `other` onto the end of biological sequence `seq`.
+Modifies and returns `seq`.
+"""
+function Base.append!(seq::BioSequence, other::BioSequence)
+    resize!(seq, length(seq) + length(other))
+    copyto!(seq, lastindex(seq) - length(other) + 1, other, 1)
     return seq
 end

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -21,8 +21,25 @@ Base.empty!(seq::BioSequence) = resize!(seq, 0)
 Append a biological symbol `x` to a biological sequence `seq`.
 """
 function Base.push!(seq::BioSequence, x)
-    # Resize makes nessecery COW checks.
+    if eltype(seq) !== typeof(x)
+        throw(ArgumentError("Can't push a $(typeof(x)) onto a sequence of $(eltype(seq))"))
+    end
     resize!(seq, length(seq) + 1)
     unsafe_setindex!(seq, x, lastindex(seq))
     return seq
+end
+
+"""
+    pop!(seq::BioSequence)
+
+Remove the symbol from the end of a biological sequence `seq` and return it.
+Returns a variable of `eltype(seq)`.
+"""
+function Base.pop!(seq::BioSequence)
+    if isempty(seq)
+        throw(ArgumentError("sequence must be non-empty"))
+    end
+    @inbounds x = seq[end]
+    deleteat!(seq, lastindex(seq))
+    return x
 end

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -130,6 +130,24 @@ Base.reverse(seq::LongSequence) = reverse!(copy(seq))
 
 Make a complement sequence of `seq`.
 """
-function BioSymbols.complement(seq::T) where {T<:BioSequence{<:NucleicAcidAlphabet}}
+function BioSymbols.complement(seq::NucleotideSeq)
     return complement!(copy(seq))
+end
+
+"""
+    reverse_complement!(seq)
+
+Make a reversed complement sequence of `seq` in place.
+"""
+function reverse_complement!(seq::NucleotideSeq)
+    return complement!(reverse!(seq))
+end
+
+"""
+    reverse_complement(seq)
+
+Make a reversed complement sequence of `seq`.
+"""
+function reverse_complement(seq::NucleotideSeq)
+    return complement!(reverse(seq))
 end

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -152,6 +152,12 @@ function reverse_complement(seq::NucleotideSeq)
     return complement!(reverse(seq))
 end
 
+"Create a copy of a sequence with gap characters removed."
+ungap(seq::BioSequence)  =  filter(x -> x != gap(eltype(seq)), seq)
+
+"Remove gap characters from an input sequence."
+ungap!(seq::BioSequence) = filter!(x -> x != gap(eltype(seq)), seq)
+
 # Shuffle
 # -------
 

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -9,14 +9,14 @@
 
 
 """
-    empty!(seq)
+    empty!(seq::BioSequence)
 
 Completely empty a biological sequence `seq` of nucleotides.
 """
 Base.empty!(seq::BioSequence) = resize!(seq, 0)
 
 """
-    push!(seq, x)
+    push!(seq::BioSequence, x)
 
 Append a biological symbol `x` to a biological sequence `seq`.
 """
@@ -45,7 +45,7 @@ function Base.pop!(seq::BioSequence)
 end
 
 """
-    insert!(seq, i, x)
+    insert!(seq::BioSequence, i, x)
 
 Insert a biological symbol `x` into a biological sequence `seq`, at the given
 index `i`.
@@ -58,5 +58,34 @@ function Base.insert!(seq::BioSequence, i::Integer, x)
     resize!(seq, length(seq) + 1)
     copyto!(seq, i + 1, seq, i, lastindex(seq) - i)
     unsafe_setindex!(seq, x, i)
+    return seq
+end
+
+"""
+    deleteat!(seq::BioSequence, range::UnitRange{<:Integer})
+
+Deletes a defined `range` from a biological sequence `seq`.
+
+Modifies the input sequence.
+"""
+function Base.deleteat!(seq::BioSequence, range::UnitRange{<:Integer})
+    checkbounds(seq, range)
+    copyto!(seq, range.start, seq, range.stop + 1, length(seq) - range.stop)
+    resize!(seq, length(seq) - length(range))
+    return seq
+end
+
+"""
+    deleteat!(seq::BioSequence, i::Integer)
+
+Delete a biological symbol at a single position `i` in a biological sequence
+`seq`.
+
+Modifies the input sequence.
+"""
+function Base.deleteat!(seq::BioSequence, i::Integer)
+    checkbounds(seq, i)
+    copyto!(seq, i, seq, i + 1, length(seq) - i)
+    resize!(seq, length(seq) - 1)
     return seq
 end

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -124,3 +124,12 @@ end
 Base.filter(f::Function, seq::BioSequence) = filter!(f, copy(seq))
 Base.map(f::Function, seq::BioSequence) = map!(f, copy(seq))
 Base.reverse(seq::LongSequence) = reverse!(copy(seq))
+
+"""
+    complement(seq)
+
+Make a complement sequence of `seq`.
+"""
+function BioSymbols.complement(seq::T) where {T<:BioSequence{<:NucleicAcidAlphabet}}
+    return complement!(copy(seq))
+end

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -14,3 +14,15 @@
 Completely empty a biological sequence `seq` of nucleotides.
 """
 Base.empty!(seq::BioSequence) = resize!(seq, 0)
+
+"""
+    push!(seq, x)
+
+Append a biological symbol `x` to a biological sequence `seq`.
+"""
+function Base.push!(seq::BioSequence, x)
+    # Resize makes nessecery COW checks.
+    resize!(seq, length(seq) + 1)
+    unsafe_setindex!(seq, x, lastindex(seq))
+    return seq
+end

--- a/src/biosequences/transformations.jl
+++ b/src/biosequences/transformations.jl
@@ -120,3 +120,7 @@ function Base.pushfirst!(seq::BioSequence, x)
     unsafe_setindex!(seq, x, 1)
     return seq
 end
+
+function Base.filter(f::Function, seq::BioSequence)
+    return filter!(f, copy(seq))
+end

--- a/src/bit-manipulation/bit-manipulation.jl
+++ b/src/bit-manipulation/bit-manipulation.jl
@@ -15,6 +15,17 @@ end
      return x
 end
 
+@inline function complementbits(x::UInt64, ::T) where {T <: NucleicAcidAlphabet{2}}
+    return ~x
+end
+
+@inline function complementbits(x::UInt64, ::T) where {T <: NucleicAcidAlphabet{4}}
+    return (
+        ((x & 0x1111111111111111) << 3) | ((x & 0x8888888888888888) >> 3) |
+        ((x & 0x2222222222222222) << 1) | ((x & 0x4444444444444444) >> 1)
+    )
+end
+
 function gc_bitcount(x::UInt64, ::BitsPerSymbol{2})
     msk = 0x5555555555555555
     c = x & msk

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -128,13 +128,6 @@ function Base.resize!(seq::LongSequence{A}, size::Integer) where {A}
     return seq
 end
 
-"""
-    empty!(seq)
-
-Completely empty a biological sequence `seq` of nucleotides.
-"""
-Base.empty!(seq::LongSequence) = resize!(seq, 0)
-
 function Base.filter!(f::Function, seq::LongSequence{A}) where {A}
     orphan!(seq)
 

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -5,34 +5,9 @@
 
 
 
-"""
-    deleteat!(seq::LongSequence, range::UnitRange{<:Integer})
 
-Deletes a defined `range` from a biological sequence `seq`.
 
-Modifies the input sequence.
-"""
-function Base.deleteat!(seq::LongSequence{A}, range::UnitRange{<:Integer}) where {A}
-    checkbounds(seq, range)
-    copyto!(seq, range.start, seq, range.stop + 1, length(seq) - range.stop)
-    resize!(seq, length(seq) - length(range))
-    return seq
-end
 
-"""
-    deleteat!(seq::LongSequence, i::Integer)
-
-Delete a biological symbol at a single position `i` in a biological sequence
-`seq`.
-
-Modifies the input sequence.
-"""
-function Base.deleteat!(seq::LongSequence, i::Integer)
-    checkbounds(seq, i)
-    copyto!(seq, i, seq, i + 1, length(seq) - i)
-    resize!(seq, length(seq) - 1)
-    return seq
-end
 
 """
     append!(seq, other)

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -11,20 +11,7 @@
 
 
 
-"""
-    popfirst!(seq)
 
-Remove the symbol from the beginning of a biological sequence `seq` and return
-it. Returns a variable of `eltype(seq)`.
-"""
-function Base.popfirst!(seq::LongSequence)
-    if isempty(seq)
-        throw(ArgumentError("sequence must be non-empty"))
-    end
-    x = seq[1]
-    deleteat!(seq, 1)
-    return x
-end
 
 """
     pushfirst!(seq, x)

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -121,15 +121,6 @@ function complement!(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
 end
 
 """
-    complement(seq)
-
-Make a complement sequence of `seq`.
-"""
-function BioSymbols.complement(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
-    return complement!(copy(seq))
-end
-
-"""
     reverse_complement!(seq)
 
 Make a reversed complement sequence of `seq` in place.

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -1,20 +1,7 @@
 # Transformations
 # ---------------
 
-"""
-    pop!(seq::LongSequence)
 
-Remove the symbol from the end of a biological sequence `seq` and return it.
-Returns a variable of `eltype(seq)`.
-"""
-function Base.pop!(seq::LongSequence)
-    if isempty(seq)
-        throw(ArgumentError("sequence must be non-empty"))
-    end
-    x = seq[end]
-    deleteat!(seq, lastindex(seq))
-    return x
-end
 
 """
     insert!(seq, i, x)

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -1,20 +1,6 @@
 # Transformations
 # ---------------
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 """
     resize!(seq, size)
 
@@ -65,10 +51,6 @@ function Base.map!(f::Function, seq::LongSequence)
         unsafe_setindex!(seq, f(inbounds_getindex(seq, i)), i)
     end
     return seq
-end
-
-function Base.map(f::Function, seq::LongSequence)
-    return map!(f, copy(seq))
 end
 
 """

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -69,13 +69,6 @@ function Base.reverse!(seq::LongSequence)
     return seq
 end
 
-"""
-    reverse(seq)
-
-Create a sequence which is the reverse of the bioloigcal sequence `seq`.
-"""
-Base.reverse(seq::LongSequence) = reverse!(copy(seq))
-
 function Base.reverse(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
     data = Vector{UInt64}(undef, seq_data_len(A, length(seq)))
     i = 1

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -123,10 +123,6 @@ end
 # Shuffle
 # -------
 
-function Random.shuffle(seq::LongSequence)
-    return shuffle!(copy(seq))
-end
-
 function Random.shuffle!(seq::LongSequence)
     orphan!(seq)
     # Fisher-Yates shuffle

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -13,18 +13,7 @@
 
 
 
-"""
-    pushfirst!(seq, x)
 
-Insert a biological symbol `x` at the beginning of a biological sequence `seq`.
-"""
-function Base.pushfirst!(seq::LongSequence{A}, x) where {A}
-    bin = enc64(seq, x)
-    resize!(seq, length(seq) + 1)
-    copyto!(seq, 2, seq, 1, length(seq) - 1)
-    encoded_setindex!(seq, bin, 1)
-    return seq
-end
 
 """
     resize!(seq, size)

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -114,31 +114,14 @@ end
 
 Make a complement sequence of `seq` in place.
 """
-function complement!(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet{2}}
+function complement!(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
     orphan!(seq)
     next = firstbitindex(seq)
     stop = bitindex(seq, lastindex(seq) + 1)
+    seqdata = seq.data
     @inbounds while next < stop
-        seq.data[index(next)] = ~seq.data[index(next)]
-        next += 64
-    end
-    return seq
-end
-
-"""
-    complement!(seq)
-
-Transform `seq` into it's complement.
-"""
-function complement!(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet{4}}
-    orphan!(seq)
-    next = firstbitindex(seq)
-    stop = bitindex(seq, lastindex(seq) + 1)
-    @inbounds while next < stop
-        x = seq.data[index(next)]
-        seq.data[index(next)] = (
-            ((x & 0x1111111111111111) << 3) | ((x & 0x8888888888888888) >> 3) |
-            ((x & 0x2222222222222222) << 1) | ((x & 0x4444444444444444) >> 1))
+        x = seqdata[index(next)]
+        seqdata[index(next)] = complementbits(x, Alphabet(seq))
         next += 64
     end
     return seq

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -120,24 +120,6 @@ function complement!(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
     return seq
 end
 
-"""
-    reverse_complement!(seq)
-
-Make a reversed complement sequence of `seq` in place.
-"""
-function reverse_complement!(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
-    return complement!(reverse!(seq))
-end
-
-"""
-    reverse_complement(seq)
-
-Make a reversed complement sequence of `seq`.
-"""
-function reverse_complement(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
-    return complement!(reverse(seq))
-end
-
 # Shuffle
 # -------
 

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -9,18 +9,7 @@
 
 
 
-"""
-    append!(seq, other)
 
-Add a biological sequence `other` onto the end of biological sequence `seq`.
-Modifies and returns `seq`.
-"""
-function Base.append!(seq::LongSequence{A},
-		      other::LongSequence{A}) where {A}
-    resize!(seq, length(seq) + length(other))
-    copyto!(seq, lastindex(seq) - length(other) + 1, other, 1)
-    return seq
-end
 
 """
     popfirst!(seq)

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -2,18 +2,6 @@
 # ---------------
 
 """
-    push!(seq::LongSequence{A}, x) where {A}
-
-Append a biological symbol `x` to a biological sequence `seq`.
-"""
-function Base.push!(seq::LongSequence{A}, x) where {A}
-    bin = enc64(seq, x)
-    resize!(seq, length(seq) + 1)
-    encoded_setindex!(seq, bin, lastindex(seq))
-    return seq
-end
-
-"""
     pop!(seq::LongSequence)
 
 Remove the symbol from the end of a biological sequence `seq` and return it.

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -59,10 +59,6 @@ function Base.filter!(f::Function, seq::LongSequence{A}) where {A}
     return seq
 end
 
-function Base.filter(f::Function, seq::LongSequence)
-    return filter!(f, copy(seq))
-end
-
 function Base.map!(f::Function, seq::LongSequence)
     orphan!(seq)
     for i in 1:lastindex(seq)

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -3,20 +3,7 @@
 
 
 
-"""
-    insert!(seq, i, x)
 
-Insert a biological symbol `x` into a biological sequence `seq`, at the given
-index `i`.
-"""
-function Base.insert!(seq::LongSequence{A}, i::Integer, x) where {A}
-    checkbounds(seq, i)
-    bin = enc64(seq, x)
-    resize!(seq, length(seq) + 1)
-    copyto!(seq, i + 1, seq, i, lastindex(seq) - i)
-    encoded_setindex!(seq, bin, i)
-    return seq
-end
 
 """
     deleteat!(seq::LongSequence, range::UnitRange{<:Integer})


### PR DESCRIPTION
This PR moves and edits some of the methods defined for LongSequence, as under the new API for abstract BioSequence types, this could allow some of these methods to be defined generally at a higher level.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [ ] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
