### PR TITLE
Faster conversion to String

### DIFF
--- a/src/biosequence/conversion.jl
+++ b/src/biosequence/conversion.jl
@@ -7,9 +7,58 @@
 ### This file is a part of BioJulia.
 ### License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
+# Create a lookup table from biosymbol to the UInt8 for the character that would
+# represent it in a string, e.g. DNA_G -> UInt8('G')
+for alphabettype in ("DNA", "RNA", "AminoAcid")
+    tablename = Symbol(uppercase(alphabettype), "_TO_BYTE")
+    typ = Symbol(alphabettype)
+    @eval begin
+        const $(tablename) = let
+            alph = alphabet($(typ))
+            bytes = zeros(UInt8, length(alph))
+            @inbounds for letter in alph
+                bytes[reinterpret(UInt8, letter) + 1] = UInt8(Char(letter))
+            end
+            Tuple(bytes)
+        end
+        stringbyte(x::$(typ)) = @inbounds $(tablename)[reinterpret(UInt8, x) + 1]
+    end
+end
+
+# Less efficient fallback. Should only be called for symbols of AsciiAlphabet
+stringbyte(x::BioSymbol) = UInt8(Char(x))
+
+abstract type AlphabetCode end
+struct AsciiAlphabet <: AlphabetCode end
+struct UnicodeAlphabet <: AlphabetCode end
+
+function codetype(::A) where {A <: Union{DNAAlphabet{2}, DNAAlphabet{4},
+                                         RNAAlphabet{2}, RNAAlphabet{4},
+                                         AminoAcidAlphabet}}
+    return AsciiAlphabet()
+end
+codetype(::Alphabet) = UnicodeAlphabet()
+
 function Base.convert(::Type{S}, seq::BioSequence) where {S<:AbstractString}
+    return convert(S, seq, codetype(Alphabet(seq)))
+end
+
+@inline function Base.convert(::Type{S}, seq::BioSequence, ::AlphabetCode) where {S<:AbstractString}
     return S([Char(x) for x in seq])
 end
+
+@inline function Base.convert(::Type{String}, seq::BioSequence, ::AsciiAlphabet)
+    len = length(seq)
+    str = Base._string_n(len)
+    GC.@preserve str begin
+        p = pointer(str)
+        @inbounds for i in 1:len
+            unsafe_store!(p, stringbyte(seq[i]), i)
+        end
+    end
+    return str
+end
+
 Base.String(seq::BioSequence) = convert(String, seq)
 
 Base.convert(::Type{Vector{DNA}}, seq::BioSequence{<:DNAAlphabet}) = collect(seq)


### PR DESCRIPTION
# Faster conversion to String from BioSequence

This is a rewrite of the BioSequence -> String conversion part of BioSequences. It was inspired by our discussion regarding the new language Seq, which *alledgedly* kicks BioSequences' butt in performance benchmarks.

The change is purely internal and does not change any API. I've run tests, but not changed any documentation or the like since it's not user-facing.

The code is slightly more complex than strictly necessary. The reason is that the optimization is only possible because we can guarantee that all symbols in the known alphabets are ASCII characters. That might not be true for a user-defined alphabet. So I've implemented a fallback method that works generically for conversion from a sequence of any Alphabet to any AbstractString (identical to the previously used method). And I've implemented a trait `AsciiAlphabet` that lets the user take advantage of the optimization with any new alphabet.

Here's a quick benchmark:

```
Conversion of LongSequence{DNAAlphabet{4}} to String:
Length after ns   before ns
20     80         222
50     114        345
150    220        781
1000   1143       4699
10000  10836      59685

Conversion of DNAKmer{K} to String
K   after ns  before ns
3   58        114
32  82        267
```