### PR TITLE
Fast ASCII String to LongSequence conversion

### DIFF
--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -1,6 +1,6 @@
 ###
 ### Constructors
-### 
+###
 ###
 ### Constructor methods for LongSequences.
 ###
@@ -21,6 +21,18 @@ LongSequence(::Type{Char}) = LongCharSeq()
 
 function LongSequence()
     return LongSequence{VoidAlphabet}(Vector{UInt64}(), 0:-1, false)
+end
+
+# Specific method to avoid calculating length of ASCII seq
+function LongSequence{A}(src::String) where {A<:Alphabet}
+    if isascii(src)
+        v = unsafe_wrap(Vector{UInt8}, src)
+        return LongSequence{A}(v)
+    else
+        len = length(src)
+        seq = LongSequence{A}(len)
+        return encode_copy!(seq, 1, src, 1, len)
+    end
 end
 
 function LongSequence{A}(


### PR DESCRIPTION
# Fast ASCII String to LongSequence conversion

This PR makes it so that if a LongSequence is constructed from a String, or `encode_copy!`'ed from a String, it detects if the String is an ASCII string. If so, it wraps a byte vector around it and uses the faster vector to LongSequence conversion path.

Edit: Should probably post some benchmarks. Here, I run `LongSequence{DNAAlphabet{4}}(st)` for varying lengths of string:
```
Len   Before     After (time in ns)
    0     48        62
    1     60        75
   50    635       134
  150   1863       294
 1000  11630      1164
10000 115815     10220
```