### PR TITLE
More efficient ASCII/LongSequence conversion

### DIFF
--- a/src/alphabet.jl
+++ b/src/alphabet.jl
@@ -289,8 +289,16 @@ end
 
 # AsciiAlphabet trait - add to user defined type to use speedups.
 # Must define methods codetype, stringbyte,
+"Abstract trait for ASCII/Unicode dispatch. See `AsciiAlphabet`"
 abstract type AlphabetCode end
+
+"""Trait for alphabet using ASCII characters as String representation.
+Define `codetype(A) = AsciiAlphabet()` for a user-defined `Alphabet` A to gain speed.
+Methods needed: `stringbyte(::eltype(A))` and `stringbyte(A, ::UInt8)`.
+"""
 struct AsciiAlphabet <: AlphabetCode end
+
+"Trait for alphabet using Unicode. See `AsciiAlphabet`"
 struct UnicodeAlphabet <: AlphabetCode end
 
 function codetype(::A) where {A <: Union{DNAAlphabet{2}, DNAAlphabet{4},

--- a/src/biosequence/conversion.jl
+++ b/src/biosequence/conversion.jl
@@ -7,37 +7,7 @@
 ### This file is a part of BioJulia.
 ### License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
-# Create a lookup table from biosymbol to the UInt8 for the character that would
-# represent it in a string, e.g. DNA_G -> UInt8('G')
-for alphabettype in ("DNA", "RNA", "AminoAcid")
-    tablename = Symbol(uppercase(alphabettype), "_TO_BYTE")
-    typ = Symbol(alphabettype)
-    @eval begin
-        const $(tablename) = let
-            alph = alphabet($(typ))
-            bytes = zeros(UInt8, length(alph))
-            @inbounds for letter in alph
-                bytes[reinterpret(UInt8, letter) + 1] = UInt8(Char(letter))
-            end
-            Tuple(bytes)
-        end
-        stringbyte(x::$(typ)) = @inbounds $(tablename)[reinterpret(UInt8, x) + 1]
-    end
-end
 
-# Less efficient fallback. Should only be called for symbols of AsciiAlphabet
-stringbyte(x::BioSymbol) = UInt8(Char(x))
-
-abstract type AlphabetCode end
-struct AsciiAlphabet <: AlphabetCode end
-struct UnicodeAlphabet <: AlphabetCode end
-
-function codetype(::A) where {A <: Union{DNAAlphabet{2}, DNAAlphabet{4},
-                                         RNAAlphabet{2}, RNAAlphabet{4},
-                                         AminoAcidAlphabet}}
-    return AsciiAlphabet()
-end
-codetype(::Alphabet) = UnicodeAlphabet()
 
 function Base.convert(::Type{S}, seq::BioSequence) where {S<:AbstractString}
     return convert(S, seq, codetype(Alphabet(seq)))

--- a/src/biosequence/conversion.jl
+++ b/src/biosequence/conversion.jl
@@ -17,7 +17,7 @@ end
     return S([Char(x) for x in seq])
 end
 
-@inline function Base.convert(::Type{String}, seq::BioSequence, ::AsciiAlphabet)
+function Base.convert(::Type{String}, seq::BioSequence, ::AsciiAlphabet)
     len = length(seq)
     str = Base._string_n(len)
     GC.@preserve str begin

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -1,6 +1,6 @@
 ###
 ### Constructors
-### 
+###
 ###
 ### Constructor methods for LongSequences.
 ###
@@ -23,6 +23,20 @@ function LongSequence()
     return LongSequence{VoidAlphabet}(Vector{UInt64}(), 0:-1, false)
 end
 
+function LongSequence{A}(s::String) where {A<:Alphabet}
+    return LongSequence{A}(s, codetype(A()))
+end
+
+function LongSequence{A}(s::String, ::AsciiAlphabet) where {A<:Alphabet}
+    seq = LongSequence{A}(ncodeunits(s))
+    return encode_chunks!(seq, 1, unsafe_wrap(Vector{UInt8}, s), 1, ncodeunits(s))
+end
+
+function LongSequence{A}(s::String, ::AlphabetCode) where {A<:Alphabet}
+    seq = LongSequence{A}(length(s))
+    return encode_copy!(seq, 1, s, 1)
+end
+
 function LongSequence{A}(
         src::Union{AbstractString,AbstractVector},
         startpos::Integer=1,
@@ -31,7 +45,7 @@ function LongSequence{A}(
     seq = LongSequence{A}(len)
     #println("Made empty sequence ", seq)
     #println("Making the encode_copy!")
-    return encode_copy!(seq, 1, src, startpos, len)
+    return encode_copy!(seq, 1, src, startpos)
 end
 
 # create a subsequence


### PR DESCRIPTION
# Refactoring/rewrite of ASCII/Longsequence conversion

This PR supersedes #81 and resolves issue #82. It is a change in the internals of BioSequence to gain more performance. Behaviour should not be changed by this PR.

In BioSequences, a biological symbol is represented in three different format:
* As a specialized type, e.g `DNA_G`
* As a Char, e.g. `'G'`
* As the encoded bits in an alphabet, e.g. `0x02` for `RNAAlphabet{2}`

BioSequences + BioSymbols provide efficient, generic conversions between these three. Some alphabets, however, including the five most used ones, have a further property: Their `Char` encodings are all ASCII, which means they have another representation:
* UInt8 represention, e.g. `UInt8('G')`, which is also their `String` codeunit representation.

For these alphabets, this representation can replace `Char`, and we can rely on base Julia to convert efficiently between UInt8 and Char. This property enables much more efficient String/LongSequence/byte operations for these alphabets, but it is not used by BioSequences.

This PR is an attempt to provide a coherent, *internal* (NOT an API) interface for efficient conversions to and from the UInt8 representation.

The interface will be generic in the sense that user-defined alphabets need only implement a few specific methods to get full performance. This is implemented via the `codetype` trait.

### But why?
Speed. Also, it gives developers some kind of guarantee that they can assume ASCII symbols for some alphabets, which can make things much easier.

Here's a short benchmark showing pretty big improvements. This is the time taken to instantiate a `LongSequence` from a `String`. (updated 2020-01-14):
```
2-bit nucleotides
Length  before   after
     0      51      51
     1      61      53
    50     651      93
   150    1947     158
  1000   12108     629
 10000  119868    5944
100000 1204272   56989

4-bit nucleotides
Length  before   after
     0      51      51
     1      75      55
    50    1302      87
   150    3703     151
  1000   24654     654
 10000  244861    6128
100000 2510870   78783

amino acids
Length  before   after
     0      51      50
     1      64      53
    50     825      84
   150    2429     149
  1000   15396     665
 10000  153504    6546
100000 1581427   99056
```
There are also performance benefits for `encode_copy!` of strings and `Vector{UInt8}`, though they are smaller.

### Things to review
Let's look through the possible conversions:
* `UInt8` -> symbol: Not implemented, probably not needed
* `UInt8` -> encoding: Implemented by this PR
* `UInt8` -> `Char`: Implemented efficiently in Base
* symbol -> `UInt8`: Implemented by `stringbyte` function in #80 
* symbol -> encoding: Efficiently implemented in by `encode`
* symbol -> `Char`: NOT efficiently implemented, could use a PR.
* encoding ->`UInt8`: Not efficiently implemented. Perhaps of use for speeding up String conversion?
* encoding -> symbol: Efficiently implemented by `decode`
* encoding -> `Char`: Not efficiently implemented, but not needed.
* `Char` -> `UInt8`: Efficiently implemented in Base
* `Char` -> symbol: Efficiently implemented in BioSymbols
* `Char` -> encoding: Not efficienly implemented, does a `Char` -> symbol -> encoding. Probably not needed to be efficient.

So to me it seems only symbol -> `Char` and encoding -> `UInt8` are interesting to look at.

### To do
* ~~Add docstring to `AsciiAlphabet` to tell what user needs to define to make it work.~~
* ~~Make symbol -> Char more efficient in BioSymbols.~~
* ~~Possibly implement encoding -> UInt8 conversion for even faster conversion to `String`~~ edit: This turns out to be relatively hard to do, and will take maybe 100 lines of code. Not worth the complexity, IMO. Parsing from Strings is more important than parsing to Strings.
* ~~Review tests again to make sure everything new done by this PR is covered in the test cases.~~