### PR TITLE
Faster reverse! of LongSequence

### DIFF
--- a/src/bit-manipulation/bit-manipulation.jl
+++ b/src/bit-manipulation/bit-manipulation.jl
@@ -14,6 +14,8 @@ end
      return bswap(x)
 end
 
+reversebits(x::T, ::BitsPerSymbol{8}) where T <: Base.BitUnsigned = bswap(x)
+
 @inline function complement_bitpar(x::Unsigned, ::T) where {T<:NucleicAcidAlphabet{2}}
     return ~x
 end

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -71,7 +71,8 @@ function _reverse!(seq::LongSequence{A}, ::BitsPerSymbol) where {A <: Alphabet}
     return seq
 end
 
-function _reverse!(seq::LongSequence{A}, B::BT) where {A <: Alphabet,
+# Inline this large function because it is only called by wrapper functions
+@inline function _reverse!(seq::LongSequence{A}, B::BT) where {A <: Alphabet,
     BT <: Union{BitsPerSymbol{2}, BitsPerSymbol{4}, BitsPerSymbol{8}}}
 
     # Reverse order of chunks and bits in chunks in one pass
@@ -87,15 +88,17 @@ function _reverse!(seq::LongSequence{A}, B::BT) where {A <: Alphabet,
 
     # Reversion of chunk bits may have left-shifted data in chunks, so we must
     # shift them back to an offset of zero
-    lshift = offset(lastbitindex(seq) + bits_per_symbol(A()))
+    # This is written so it SIMD parallelizes - careful with changes
+    lshift = offset(bitindex(seq, last(seq.part)) + bits_per_symbol(A()))
     rshift = 64 - lshift
-    if !iszero(lshift)
-        @inbounds for i in 1:len-1
-            left = seq.data[i] >>> (rshift & 63)
-            right = seq.data[i+1] << (lshift & 63)
-            seq.data[i] = left | right
+    @inbounds if !iszero(lshift)
+        this = seq.data[1]
+        for i in 1:len-1
+            next = seq.data[i+1]
+            seq.data[i] = (this >>> (unsigned(rshift) & 63)) | (next << (unsigned(lshift) & 63))
+            this = next
         end
-        @inbounds seq.data[len] >>>= rshift
+        seq.data[len] >>>= (unsigned(rshift) & 63)
     end
 
     return seq
@@ -107,46 +110,6 @@ end
 Reverse a biological sequence.
 """
 Base.reverse(seq::LongSequence{A}) where {A<:Alphabet} = _reverse!(copy(seq), BitsPerSymbol(seq))
-
-"""
-    Base.reverse(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
-Create a reversed copy of a LongSequence representing a DNA or RNA sequence.
-This version of the copying reverse method is optimized for speed, taking advantage of
-bit-parallel operations.
-"""
-function Base.reverse(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
-    data = Vector{UInt64}(undef, seq_data_len(A, length(seq)))
-    i = 1
-    next = lastbitindex(seq)
-    stop = bitindex(seq, 0)
-    r = rem(offset(next) + bits_per_symbol(seq), 64)
-    if r == 0
-        @inbounds while next - stop > 0
-            x = seq.data[index(next)]
-            data[i] = reversebits(x, BitsPerSymbol(seq))
-            i += 1
-            next -= 64
-        end
-    else
-        @inbounds while next - stop > 64
-            j = index(next)
-            x = (seq.data[j] << (64 - r)) | (seq.data[j - 1] >> r)
-            data[i] = reversebits(x, BitsPerSymbol(seq))
-            i += 1
-            next -= 64
-        end
-        if next - stop > 0
-            j = index(next)
-            x = seq.data[j] << (64 - r)
-            if r < next - stop
-                x |= seq.data[j - 1] >> r
-            end
-            data[i] = reversebits(x, BitsPerSymbol(seq))
-        end
-    end
-    return LongSequence{A}(data, 1:length(seq), false)
-end
-
 
 """
     complement!(seq)

--- a/test/longsequences/transformations.jl
+++ b/test/longsequences/transformations.jl
@@ -29,6 +29,7 @@
             test_reverse(DNAAlphabet{4}, random_dna(len))
             test_reverse(RNAAlphabet{4}, random_rna(len))
             test_reverse(AminoAcidAlphabet, random_aa(len))
+            test_reverse(CharAlphabet, random_aa(len))
 
             probs = [0.25, 0.25, 0.25, 0.25, 0.00]
             test_reverse(DNAAlphabet{2}, random_dna(len, probs))


### PR DESCRIPTION
# Faster reverse! of LongSequence

Another speed-related internal change. So, currently `reverse` was up to 100x faster than `reverse!` because the former used neat bit-tricks that the latter didn't. So, why didn't the latter do it? Because the bit tricks only worked when copying the underlying data vector.

This PR adds new tricks to allow `reverse!` to be fast, too. See benchmarks at the bottom.

### EDIT: With newest changes, this version is faster than old one. No decision anymore.
**Here's the decision:** With this PR there are two similar bit-hacks for speeding up reverse-complementation. It would be nice to discard the old `reverse` and instead implement reverse simply as `_reverse!(copy(seq), BitsPerSymbol(seq))`. _But this would be slower than the old_ `reverse`, because `copy(seq)` is slow.

Here's a benchmark of what happens **if I discard the old `reverse`**. The regression is about 20-35%. However, if we allow `reverse` to call `orphan!`, the speed can be kept without keeping the old, more complex code. This will cause an unneeded copy in some cases.
```
Inplace reverse!
Type   Len    Before    After
2-bit  0         10       11
2-bit  1         10       15 
2-bit  32       394       14
2-bit  500     5928       38
2-bit  5000   58627      198
4-bit  0         10       11
4-bit  1         10       15
4-bit  32       359       20
4-bit  500     5343       49
4-bit  5000   53449      324
AA     0         12       11
AA     1         12       14
AA     32       367       20
AA     500     5455       76
AA     5000   54672      229

Copying reverse
Type   Len    Before    After
2-bit  0         37       44
2-bit  1         40       49 
2-bit  32        40       48
2-bit  500       70       82
2-bit  5000     338      402
4-bit  0         37       43
4-bit  1         39       47
4-bit  32        40       50
4-bit  500       83      102
4-bit  5000     527      708
AA     0         54       48
AA     1         58       53
AA     32       418       60
AA     500     5572      148
AA     5000   54844     1054 
```

So, is it worth keeping the old `reverse` for a 20-35% faster reversion, or should it be discarded to keep the code complexity lower?