### PR TITLE
Faster copying of LongSeq

### DIFF
--- a/src/longsequences/copying.jl
+++ b/src/longsequences/copying.jl
@@ -24,7 +24,7 @@ end
     if dst.shared || (dst === src && doff > soff)
         orphan!(dst, length(dst), true)
     end
-    
+
     id = bitindex(dst, doff)
     is = bitindex(src, soff)
     #TODO: Resolve this use of bits_per_symbol
@@ -50,15 +50,18 @@ end
         is += k
         rest -= k
     end
-    
+
     return dst
 end
 
 # Actually, users don't need to create a copy of a sequence.
-function Base.copy(seq::LongSequence{A}) where {A}
-    newseq = LongSequence{A}(seq, 1:lastindex(seq))
-    orphan!(newseq, length(seq), true)  # force orphan!
-    @assert newseq.data !== seq.data
+function Base.copy(seq::LongSequence)
+    if seq.shared
+        newseq = typeof(seq)(seq.data, seq.part, true)
+        orphan!(newseq, length(seq), true)
+    else
+        newseq = typeof(seq)(copy(seq.data), seq.part, false)
+    end
     return newseq
 end
 


### PR DESCRIPTION
Raised by https://github.com/BioJulia/BioSequences.jl/pull/84#issuecomment-574141626. Basically `copy` can be faster. More importantly, it turns out that the existing implementation of `copy` modifies the input sequence by setting its `shared` flag to `true`. That unexpected datam mutation caused a timing anomaly in my benchmarking that was annoying to track down.

Anyway, modest speed improvements, but hey, it's basically free, and also it doesn't set the `shared` flag.

```
When shared is false
Length  before   after
     0      42      32
     1      46      33
    50      48      34
   150      51      36
  1000      77      53
 10000     433     370

When shared is true
Length  before   after
     0      45      44
     1      45      44
    50      47      46
   150      52      50
  1000      83      82
 10000     484     483
```