### PR TITLE
Add copy! method to LongSequence

### DIFF
--- a/src/longsequences/copying.jl
+++ b/src/longsequences/copying.jl
@@ -54,6 +54,12 @@ end
     return dst
 end
 
+function Base.copy!(dst::LongSequence{A}, src::LongSequence{A}) where {A <: Alphabet}
+    len = length(src)
+    resize!(dst, len)
+    @inbounds copyto!(dst, 1, src, 1, len)
+end
+
 # Dispatch to alphabet type
 function Base.copy!(seq::LongSequence{A}, src) where {A<:Alphabet}
    return copy!(seq, src, codetype(A()))

--- a/src/longsequences/copying.jl
+++ b/src/longsequences/copying.jl
@@ -54,6 +54,25 @@ end
     return dst
 end
 
+# Dispatch to alphabet type
+function Base.copy!(seq::LongSequence{A}, src) where {A<:Alphabet}
+   return copy!(seq, src, codetype(A()))
+end
+
+# Fast path for String + ASCII
+function Base.copy!(seq::LongSequence, src::String, ::AsciiAlphabet)
+   v = unsafe_wrap(Vector{UInt8}, src)
+   resize!(seq, length(v))
+   return encode_chunks!(seq, 1, v, 1, length(v))
+end
+
+# Generic method, cache len 'cause may be O(n) to calculate
+function Base.copy!(seq::LongSequence, src, ::AlphabetCode)
+   len = length(src)
+   resize!(seq, len)
+   return encode_copy!(seq, 1, src, 1, len)
+end
+
 # Actually, users don't need to create a copy of a sequence.
 function Base.copy(seq::LongSequence)
     if seq.shared

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -18,6 +18,35 @@
     @test copy(subseq) == dna"GTAC"
 end
 
+@testset "Copy!" begin
+    function test_copy!(seq, src)
+        @test String(src) == String(copy!(copy(seq), src))
+    end
+    # Needed because conversion to String truncates vector.
+    function test_copy!(seq, src::Vector)
+        @test String(copy(src)) == String(copy!(copy(seq), src))
+    end
+
+    probs = [0.25, 0.25, 0.25, 0.25, 0.00]
+    dna2 = LongSequence{DNAAlphabet{2}}(6)
+    dna4 = LongSequence{DNAAlphabet{4}}(6)
+    rna2 = LongSequence{RNAAlphabet{2}}(6)
+    rna4 = LongSequence{RNAAlphabet{4}}(6)
+    aa = LongSequence{AminoAcidAlphabet}(6)
+    charseq = LongSequence{CharAlphabet}(6)
+    for dtype in [Vector{UInt8}, Vector{Char}, String, Test.GenericString]
+        for len in [0, 1, 10, 16, 32, 100, 5]
+            test_copy!(dna2, dtype(random_dna(len, probs)))
+            test_copy!(dna4, dtype(random_dna(len)))
+            test_copy!(rna2, dtype(random_rna(len, probs)))
+            test_copy!(rna4, dtype(random_rna(len)))
+            test_copy!(aa, dtype(random_aa(len)))
+            test_copy!(charseq, dtype(random_aa(len)))
+        end
+    end
+    test_copy!(charseq, "ϐʌ⨝W")
+end
+
 @testset "Concatenation" begin
     function test_concatenation(A, chunks)
         parts = UnitRange{Int}[]


### PR DESCRIPTION
# Add copy! method to LongSequence

The method is intended to be used for something like this:
```
seq = LongSequence{DNAAlphabet{2}}()
for line in eachline(file)
    copy!(seq, line)
    # process seq somehow
end
```

This is highly efficient, not reallocating the `LongSequence`. Note that this can potentially be useful in FASTX, since you can also `copy!` views of the underlying FASTA data.

The `copy!(dst, src)` methods works like arrays, copying to the dst and resizing it. Its implementation is effectively:
```
function copy!(dst, src)
    resize!(dst, length(src))
    copyto!(dst, src)
end
```

* For LongSequence -> LongSequence of same alphabet, it simply calls `resize!`, then inbounds `copyto!`.
* For String -> ASCII alphabet LongSequence, it avoids calling the O(n) `length(string)` by wrapping it in a byte vector, then using `resize!` and `encode_chunks!`.
* For any other source -> LongSequence, it calls `resize!`, then `encode_copy!`