### PR TITLE
Fix orphan! bug

### DIFF
--- a/src/longsequences/longsequence.jl
+++ b/src/longsequences/longsequence.jl
@@ -90,12 +90,11 @@ function orphan!(seq::LongSequence,
 	if !seq.shared & !force
 	    return seq
 	end
-	return _orphan!(seq, size, force)
+	return _orphan!(seq, size)
 end
 
 function _orphan!(seq::LongSequence{A},
-		 size::Integer = length(seq),
-		 force::Bool = false) where {A}
+		 size::Integer = length(seq)) where {A}
 
     j, r = bitindex(seq, 1)
     data = Vector{UInt64}(undef, seq_data_len(A, size))

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -8,13 +8,13 @@
 Resize a biological sequence `seq`, to a given `size`.
 """
 function Base.resize!(seq::LongSequence{A}, size::Integer) where {A}
-    if size < 0
+    if size == length(seq)
+        return seq
+    elseif size < 0
         throw(ArgumentError("size must be non-negative"))
+    else
+        return _orphan!(seq, size)
     end
-    orphan!(seq, size)
-    resize!(seq.data, seq_data_len(A, size + seq.part.start - 1))
-    seq.part = seq.part.start:seq.part.start+size-1
-    return seq
 end
 
 function Base.filter!(f::Function, seq::LongSequence{A}) where {A}
@@ -63,7 +63,7 @@ function Base.reverse!(seq::LongSequence)
     orphan!(seq) # TODO: Is the orphan call really nessecery given the indexing calls will also call orphan?
     @inbounds for i in 1:div(lastindex(seq), 2)
 	    x = seq[i]
-        i′ = lastindex(seq) - i + 1 
+        i′ = lastindex(seq) - i + 1
 	    seq[i] = seq[i′]
 	    seq[i′] = x
     end

--- a/test/longsequences/mutability.jl
+++ b/test/longsequences/mutability.jl
@@ -161,5 +161,9 @@
         subseq = seq[16:17]
         BioSequences.orphan!(subseq)
         @test subseq == dna"TA"
+
+        subseq = seq[16:20]
+        BioSequences.orphan!(subseq, 3)
+        @test subseq == dna"TAC"
     end
 end


### PR DESCRIPTION
# Fix orphan! bug

This PR makes four changes:
### 1: Fix bug in orphan!
Currently on `master`:
```
julia> a =  BioSequences.orphan!(LongDNASeq("A"^17), 16, true)
17nt DNA Sequence:
AAAAAAAAAAAAAAAA-

julia> a.data
1-element Array{UInt64,1}:
 0x1111111111111111
```
This is fixed in this branch

### 2: Optimize orphan!
Because why not, it's used all the time internally. It's especially important that it's fast when the sequence is not shared (as is likely the case most of the time). See benchmarks at bottom.

### 3: Optimize `length(::LongSequence)`
Current imlpementation checks for overflows, which is only possible if the `part` field contains negative numbers. But this can never happen, and if it does, it causes all kinds of bugs anyway (like `eachindex` not agreeing with `firstindex` etc). It also causes an annoying branch that actually can cause significant slowdown.

### 4: Optimize `resize!`
Make it do nothing if size does not change, and then use the newly-introduces `_orphan!` to more effectively do the resize if necessary.

### Benchmarks
```
Orphan! non-shared seq
Len     Before    After
0       6.8       1.9  
1       7.2       1.7
15      7.1       1.7
32      7.1       1.7
500     7.0       1.9
50000   7.1       1.7

Force orphan! non-shared seq
Len     Before    After
0       31.5      29.0
1       35.2      32.0
15      35.2      31.8
32      36.0      32.8
500     52.5      47.9
50000 1816.0    1544.0

orphan! shared seq
Len     Before    After
0       41.8      36.9
1       45.0      40.8
15      45.2      39.8
32      46.0      40.6
500     63.0      56.4
50000 1852.0    1574.0
```