### PR TITLE
Faster printing

### DIFF
--- a/src/longsequences/longsequence.jl
+++ b/src/longsequences/longsequence.jl
@@ -124,6 +124,7 @@ end
 
 include("indexing.jl")
 include("constructors.jl")
+include("printing.jl")
 include("copying.jl")
 include("conversion.jl")
 include("stringliterals.jl")

--- a/src/longsequences/printing.jl
+++ b/src/longsequences/printing.jl
@@ -1,0 +1,39 @@
+# Specialized printing/showing methods
+#
+
+function Base.print(io::IO, seq::LongSequence{A}; width::Integer = 0) where {A<:Alphabet}
+    return _print(io, seq, width, codetype(A()))
+end
+
+# Dispatch to generic method in biosequences/printing.jl
+function _print(io::IO, seq::LongSequence{<:Alphabet}, width::Integer, ::AlphabetCode)
+    return _print(io, seq, width)
+end
+
+# Specialized method for ASCII alphabet
+function _print(io::IO, seq::LongSequence{<:Alphabet}, width::Integer, ::AsciiAlphabet)
+    # I don't like to have to do this, but in Julia 1.3, system buffers are IO-locked.
+    if (width < 1) | (length(seq) ≤ width)
+        return print(io, String(seq))
+    end
+    if length(seq) < 4096
+        buffer = SimpleBuffer(io, padded_length(length(seq), width))
+    else
+        buffer = SimpleBuffer(io)
+    end
+    return _print(buffer, seq, width, AsciiAlphabet())
+end
+
+function _print(buffer::SimpleBuffer, seq::LongSequence{<:Alphabet}, width::Integer, ::AsciiAlphabet)
+    col = 0
+    @inbounds for i in eachindex(seq)
+        col += 1
+        if (width > 0) & (col > width)
+            write(buffer, UInt8('\n'))
+            col = 1
+        end
+        write(buffer, stringbyte(seq[i]))
+    end
+    close(buffer)
+    return nothing
+end

--- a/test/longsequences/print.jl
+++ b/test/longsequences/print.jl
@@ -13,8 +13,20 @@
     print(buf, dna"A"^100)
     @test String(take!(buf)) == "A"^100
 
+    print(buf, dna"G"^60, width=0)
+    @test String(take!(buf)) == "G"^60
+
+    print(buf, dna"A"^60, width=-5)
+    @test String(take!(buf)) == "A"^60
+
     print(buf, dna"A"^100, width=70)
     @test String(take!(buf)) == string("A"^70, '\n', "A"^30)
+
+    print(buf, dna"A"^100, width=50)
+    @test String(take!(buf)) == string("A"^50, '\n', "A"^50)
+
+    print(buf, dna"A"^4100, width=100)
+    @test String(take!(buf)) == repeat("A"^100 * '\n', 40) * "A"^100
 end
 
 @testset "Show" begin

--- a/test/refseq/print.jl
+++ b/test/refseq/print.jl
@@ -8,6 +8,16 @@
 
     print(buf, ReferenceSequence(dna"A"^100))
     @test String(take!(buf)) == "A"^100
+
+    print(buf, ReferenceSequence(dna"A"^100), width=80)
+    @test String(take!(buf)) == "A"^80 * '\n' * "A"^20
+
+    print(buf, ReferenceSequence(dna"A"^20), width=20)
+    @test String(take!(buf)) == "A"^20
+
+    # Check more than 4096
+    print(buf, ReferenceSequence(dna"A"^4101), width=100)
+    @test String(take!(buf)) == repeat("A"^100 * '\n', 41) * "A"
 end
 
 @testset "Show" begin


### PR DESCRIPTION
# Faster printing

As discussed in #86 . 
It's a bit more complicated. `SimpleBuffer` have a type param that decides if it does any buffering (i.e. incremental dumping of data to sink), because I want to be fast in a bunch different of cases:


* For ASCII sequences, it's fastest to create a String and print it. But only do this if the string is small (so it doesn't clog up memory) and if there should be no newlines in the string (e.g. sequence length < width)
* If there should be newlines but the input seq is small, we can use a non-buffering `SimpleBuffer`, which is faster. Else use a buffering one to prevent memory waste.
* For ASCII sequence, always use the fast conversion of encoded data to String UInt8 bytes

Benchmark: Seq's "RC" benchmark on Julia 1.3 on a 1 mill line file.
```
Before: 4.33 s
After:   .62 s
```

Also added a bunch of tests. Edit: CodeCov looks good to me. This PR is ready for merge once it has been reviewed.