### PR TITLE
Misc fixes

### DIFF
--- a/src/biosequence/printing.jl
+++ b/src/biosequence/printing.jl
@@ -44,7 +44,7 @@ function Base.close(sb::SimpleBuffer)
     sb.len = 0
 end
 
-Base.print(io::IO, seq::BioSequence; width::Integer = 0) = _print(io, seq, width)
+Base.print(io::IO, seq::BioSequence; width::Integer = 0) = _print(SimpleBuffer(io), seq, width)
 
 function padded_length(len::Integer, width::Integer)
     den = ifelse(width < 1, typemax(Int), width)
@@ -53,15 +53,6 @@ end
 
 # Generic method. The different name allows subtypes of BioSequence to
 # selectively call the generic print despite being more specific type
-function _print(io::IO, seq::BioSequence, width::Integer)
-    if length(seq) < 4096
-        buffer = SimpleBuffer(io, padded_length(length(seq), width))
-    else
-        buffer = SimpleBuffer(io)
-    end
-    return _print(buffer, seq, width)
-end
-
 function _print(buffer::SimpleBuffer, seq::BioSequence, width::Integer)
     col = 0
     for x in seq

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -66,8 +66,8 @@ function Composition(iter::AbstractMerIterator{T}) where {T<:AbstractMer}
     if ksize(T) ≤ 8
         # This is faster for short k-mers.
         counts′ = zeros(Int, 4 ^ ksize(T))
-        for (_, x) in iter
-            @inbounds counts′[encoded_data(x) + 1] += 1
+        for mer in iter
+            @inbounds counts′[encoded_data(mer.fw) + 1] += 1
         end
         for x in eachindex(counts′)
             @inbounds c = counts′[x]
@@ -76,8 +76,8 @@ function Composition(iter::AbstractMerIterator{T}) where {T<:AbstractMer}
             end
         end
     else
-        for (_, x) in iter
-            counts[x] = get(counts, x, 0) + 1
+        for mer in iter
+            counts[x] = get(counts, mer.fw, 0) + 1
         end
     end
     return Composition{T}(counts)

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -23,16 +23,18 @@ function LongSequence()
     return LongSequence{VoidAlphabet}(Vector{UInt64}(), 0:-1, false)
 end
 
-function LongSequence{A}(s::String) where {A<:Alphabet}
+function LongSequence{A}(s::Union{String, SubString{String}}) where {A<:Alphabet}
     return LongSequence{A}(s, codetype(A()))
 end
 
-function LongSequence{A}(s::String, ::AsciiAlphabet) where {A<:Alphabet}
+function LongSequence{A}(s::Union{String, SubString{String}}, ::AsciiAlphabet) where {A<:Alphabet}
     seq = LongSequence{A}(ncodeunits(s))
-    return encode_chunks!(seq, 1, unsafe_wrap(Vector{UInt8}, s), 1, ncodeunits(s))
+    len = ncodeunits(s) - firstindex(s) + 1
+    v = GC.@preserve s unsafe_wrap(Vector{UInt8}, pointer(s), len)
+    return encode_chunks!(seq, 1, v, 1, ncodeunits(s))
 end
 
-function LongSequence{A}(s::String, ::AlphabetCode) where {A<:Alphabet}
+function LongSequence{A}(s::Union{String, SubString{String}}, ::AlphabetCode) where {A<:Alphabet}
     seq = LongSequence{A}(length(s))
     return encode_copy!(seq, 1, s, 1)
 end

--- a/test/longsequences/conversion.jl
+++ b/test/longsequences/conversion.jl
@@ -32,6 +32,7 @@ end
 
     for len in [0, 1, 2, 3, 10, 32, 1000, 10000]
         test_string_construction(DNAAlphabet{4}, random_dna(len))
+        test_string_construction(DNAAlphabet{4}, SubString(random_dna(len), 1:len))
         test_string_construction(DNAAlphabet{4}, lowercase(random_dna(len)))
         test_string_construction(RNAAlphabet{4}, lowercase(random_rna(len)))
         test_string_construction(RNAAlphabet{4}, random_rna(len))
@@ -39,6 +40,7 @@ end
         test_string_construction(AminoAcidAlphabet, lowercase(random_aa(len)))
 
         test_string_parse(DNAAlphabet{4}, random_dna(len))
+        test_string_parse(DNAAlphabet{4}, SubString(random_dna(len), 1:len))
         test_string_parse(DNAAlphabet{4}, lowercase(random_dna(len)))
         test_string_parse(RNAAlphabet{4}, lowercase(random_rna(len)))
         test_string_parse(RNAAlphabet{4}, random_rna(len))

--- a/test/longsequences/print.jl
+++ b/test/longsequences/print.jl
@@ -27,6 +27,12 @@
 
     print(buf, dna"A"^4100, width=100)
     @test String(take!(buf)) == repeat("A"^100 * '\n', 40) * "A"^100
+
+    print(buf, char"ϐ")
+    @test String(take!(buf)) == "ϐ"
+
+    print(buf, char"ϐaδ", width=1)
+    @test String(take!(buf)) == "ϐ\na\nδ"
 end
 
 @testset "Show" begin


### PR DESCRIPTION
# Miscellaneous fixes

### 1: Fix bug in printing of non-ASCII BioSequence
Currently on master:
```
$ julia --check-bounds=yes -e 'using BioSequences; print(char"🐛")'
ERROR: BoundsError: attempt to access 1-element Array{UInt8,1} at index [2]
Stacktrace:
 [1] setindex! at ./array.jl:769 [inlined]
 [2] write at /home/vagrant/benchmarks/BioSequences.jl/src/biosequence/printing.jl:29 [inlined]
 [3] write at ./io.jl:563 [inlined]
 [4] print at ./char.jl:213 [inlined]
 [5] _print(::BioSequences.SimpleBuffer{false,Base.TTY}, ::LongSequence{CharAlphabet}, ::Int64) at /home/vagrant/benchmarks/BioSequences.jl/src/biosequence/printing.jl:73
```
This is fixed in this PR. Also added a few tests for non-ASCII LongSequences to prevent it from happening again.

### 2: Fix erroroneous memory-inefficient printing of ASCII LongSequence
Previously, if `width` keyword of an ASCII LongSequence was set to 0 or below, or a very high number, the `String(seq)` would be called. Fixed this so it now always buffers printing for long sequences to preserve memory. As a result, printing sequences longer than 4095 elements are now slower.

### 3: Sequences can now effectively be instantiated from SubString{String}
This might be useful, and requires basically nothing to implement.

### 4: More efficient sequence composition
Large speed increase obtained by replacing
```
for (_, x) in each(DNAMer{k}, seq)
    # do stuff with x
```
to
```
for mer in each(DNAMer{k}, seq)
    # do stuff with mer.fw
```