### PR TITLE
Optimize refseq

### DIFF
--- a/src/alphabet.jl
+++ b/src/alphabet.jl
@@ -171,7 +171,7 @@ end
 EncodeError(::A, val::T) where {A,T} = EncodeError{A,T}(val)
 
 function Base.showerror(io::IO, err::EncodeError{A}) where {A}
-    print(io, "cannot encode ", err.val, " in ", A)
+    print(io, "cannot encode ", repr(err.val), " in ", A)
 end
 
 """
@@ -186,7 +186,7 @@ end
 DecodeError(::A, val::T) where {A,T} = DecodeError{A,T}(val)
 
 function Base.showerror(io::IO, err::DecodeError{A}) where {A}
-    print(io, "cannot decode ", err.val, " in ", A)
+    print(io, "cannot decode ", repr(err.val), " in ", A)
 end
 
 ###

--- a/src/nmask.jl
+++ b/src/nmask.jl
@@ -20,11 +20,11 @@ end
 Base.copy(nmask::NMask) = NMask(copy(nmask.blockmask), copy(nmask.blocks), nmask.len)
 
 function NMask(bv::BitVector)
-    n = length(bv.chunks)
+    chunks = bv.chunks
     blockmask = BitVector()
     blocks = Vector{UInt64}()
-    for i in 1:n
-        chunk = bv.chunks[i]
+    @inbounds for i in eachindex(chunks)
+        chunk = chunks[i]
         if chunk == 0
             # no N in this block
             push!(blockmask, false)
@@ -37,9 +37,9 @@ function NMask(bv::BitVector)
 end
 
 function Base.convert(::Type{BitVector}, nmask::NMask)
-    bv = BitVector()
-    for i in 1:length(nmask)
-        push!(bv, nmask[i])
+    bv = falses(length(nmask))
+    @inbounds for i in 1:length(nmask)
+        bv[i] = nmask[i]
     end
     return bv
 end


### PR DESCRIPTION
Optimize `ReferenceSequence`. Still more work to do, so no need to merge this just yet. Also want to see a CodeCov.

Also fixed an error where the error message for invalid encodings was not displayed correctly. Before:
```
julia> dna"A"[1] = 0xff
ERROR: cannot encode
Stacktrace:
[ELIDED]
```
After:
```
julia> dna"A"[1] = 0xff
ERROR: cannot encode Invalid DNA in DNAAlphabet{4}
Stacktrace:
```
It happens because the error message calls `print(::DNA)`, which itself raises an error if the DNAS is invalid. The change in this PR also changes `ERROR: cannot encode N in DNAAlphabet{2}` to `ERROR: cannot encode DNA_N in DNAAlphabet{2}` which I think is more reasonable.