### PR TITLE
Revamb copy! and copyto! interface

### DIFF
--- a/src/biosequence/transformations.jl
+++ b/src/biosequence/transformations.jl
@@ -1,4 +1,4 @@
-# Transformations 
+# Transformations
 # ===============
 #
 # Methods that manipulate and change a biological sequence.
@@ -90,7 +90,7 @@ Modifies and returns `seq`.
 """
 function Base.append!(seq::BioSequence, other::BioSequence)
     resize!(seq, length(seq) + length(other))
-    copyto!(seq, lastindex(seq) - length(other) + 1, other, 1)
+    copyto!(seq, lastindex(seq) - length(other) + 1, other, 1, length(other))
     return seq
 end
 

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -27,11 +27,11 @@ function LongSequence{A}(s::Union{String, SubString{String}}) where {A<:Alphabet
     return LongSequence{A}(s, codetype(A()))
 end
 
-# Generic method for String/Substring
+# Generic method for String/Substring.
 function LongSequence{A}(s::Union{String, SubString{String}}, ::AlphabetCode) where {A<:Alphabet}
     len = length(s)
     seq = LongSequence{A}(len)
-    return encode_copyto!(seq, 1, s, 1, len)
+    return copyto!(seq, 1, s, 1, len)
 end
 
 function LongSequence{A}(s::Union{String, SubString{String}}, ::AsciiAlphabet) where {A<:Alphabet}
@@ -46,7 +46,7 @@ function LongSequence{A}(
         stoppos::Integer=length(src)) where {A<:Alphabet}
     len = stoppos - startpos + 1
     seq = LongSequence{A}(len)
-    return encode_copyto!(seq, 1, src, startpos, len)
+    return copyto!(seq, 1, src, startpos, len)
 end
 
 # create a subsequence

--- a/src/longsequences/copying.jl
+++ b/src/longsequences/copying.jl
@@ -181,18 +181,13 @@ function Base.copy!(dst::LongSequence{<:Alphabet}, src::AbstractVector{UInt8}, :
 end
 
 function Base.copy!(dst::LongSequence{<:Alphabet}, src::SeqLike, ::AlphabetCode)
-    len = length(seq) # calculate only once
+    len = length(src) # calculate only once
     resize!(dst, len)
     return copyto!(dst, 1, src, 1, len)
 end
 
 
 ########
-
-# Helper functions for copy!
-@noinline function throw_enc_indexerr(N::Integer, len::Integer, soff::Integer)
-    throw(ArgumentError("source of length $len does not contain $N elements from $soff"))
-end
 
 for (anum, atype) in enumerate((DNAAlphabet{4}, DNAAlphabet{2}, RNAAlphabet{4},
     RNAAlphabet{2}, AminoAcidAlphabet))

--- a/src/longsequences/indexing.jl
+++ b/src/longsequences/indexing.jl
@@ -60,7 +60,7 @@ function Base.setindex!(seq::LongSequence{A},
                         locs::UnitRange{<:Integer}) where {A}
     @boundscheck checkbounds(seq, locs)
     checkdimension(other, locs)
-    return copyto!(seq, locs.start, other, 1)
+    return copyto!(seq, locs.start, other, 1, length(locs))
 end
 
 function Base.setindex!(seq::LongSequence{A},
@@ -132,3 +132,15 @@ end
     @inbounds data[j] = (bin << r) | (data[j] & ~(bindata_mask(seq) << r))
     return seq
 end
+
+#=
+function Base.iterate(seq::LongSequence{A}, off::Int=first(seq.part)-1) where {A <: Alphabet}
+    off == last(seq.part) && return nothing
+    bps = bits_per_symbol(A())
+    @inbounds chunk = seq.data[(off >>> index_shift(BitsPerSymbol(A()))) + 1]
+    shift = (unsigned(off) * bps) & 63
+    encoding = (chunk >>> shift) & bitmask(A())
+    return decode(A(), encoding), off + 1
+end
+
+=#

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -79,6 +79,11 @@ end
     test_copyto2!(RNAAlphabet{4}, random_rna)
     test_copyto2!(AminoAcidAlphabet, random_aa)
     test_copyto2!(CharAlphabet, random_aa)
+
+    # Test bug when copying to self
+    src = LongDNASeq("A"^16 * "C"^16 * "A"^16)
+    copyto!(src, 17, src, 1, 32)
+    @test String(src) == "A"^32 * "C"^16
 end
 
 @testset "Copy! data" begin

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -18,13 +18,13 @@
     @test copy(subseq) == dna"GTAC"
 end
 
-@testset "Copy!" begin
-    function test_copy!(seq, src)
-        @test String(src) == String(copy!(copy(seq), src))
+@testset "Encode copy!" begin
+    function test_encode_copy!(seq, src)
+        @test String(src) == String(BioSequences.encode_copy!(seq, src))
     end
     # Needed because conversion to String truncates vector.
-    function test_copy!(seq, src::Vector)
-        @test String(copy(src)) == String(copy!(copy(seq), src))
+    function test_encode_copy!(seq, src::Vector)
+        @test String(copy(src)) == String(BioSequences.encode_copy!(copy(seq), src))
     end
 
     probs = [0.25, 0.25, 0.25, 0.25, 0.00]
@@ -36,15 +36,15 @@ end
     charseq = LongSequence{CharAlphabet}(6)
     for dtype in [Vector{UInt8}, Vector{Char}, String, Test.GenericString]
         for len in [0, 1, 10, 16, 32, 100, 5]
-            test_copy!(dna2, dtype(random_dna(len, probs)))
-            test_copy!(dna4, dtype(random_dna(len)))
-            test_copy!(rna2, dtype(random_rna(len, probs)))
-            test_copy!(rna4, dtype(random_rna(len)))
-            test_copy!(aa, dtype(random_aa(len)))
-            test_copy!(charseq, dtype(random_aa(len)))
+            test_encode_copy!(dna2, dtype(random_dna(len, probs)))
+            test_encode_copy!(dna4, dtype(random_dna(len)))
+            test_encode_copy!(rna2, dtype(random_rna(len, probs)))
+            test_encode_copy!(rna4, dtype(random_rna(len)))
+            test_encode_copy!(aa, dtype(random_aa(len)))
+            test_encode_copy!(charseq, dtype(random_aa(len)))
         end
     end
-    test_copy!(charseq, "ϐʌ⨝W")
+    test_encode_copy!(charseq, "ϐʌ⨝W")
 end
 
 @testset "Concatenation" begin

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -1,30 +1,93 @@
-@testset "Copy" begin
-    function test_copy(A, seq)
-        @test convert(String, copy(LongSequence{A}(seq))) == seq
+@testset "Copy sequence" begin
+    # Test copy from sequence to sequence
+    function test_copy(A, str)
+        seq = LongSequence{A}(str)
+        str2 = String(copy(seq))
+        @test (str == str2 == String(seq))
     end
 
-    for len in [1, 10, 16, 32, 1000, 10000]
+    for len in [0, 1, 15, 33]
         test_copy(DNAAlphabet{4}, random_dna(len))
-        test_copy(RNAAlphabet{4}, random_rna(len))
+        test_copy(RNAAlphabet{2}, random_rna(len, [0.25, 0.25, 0.25, 0.25]))
         test_copy(AminoAcidAlphabet, random_aa(len))
-
-        probs = [0.25, 0.25, 0.25, 0.25, 0.00]
-        test_copy(DNAAlphabet{2}, random_dna(len, probs))
-        test_copy(RNAAlphabet{2}, random_rna(len, probs))
+        test_copy(CharAlphabet, random_aa(len))
     end
 
-    seq = dna"ACGTACGTACGT"
-    subseq = seq[3:6]
-    @test copy(subseq) == dna"GTAC"
+    # Test copying shared seq
+    seq = LongSequence{DNAAlphabet{2}}(random_dna(50, [0.25, 0.25, 0.25, 0.25]))
+    seq2 = seq[5:44]
+    @test String(seq)[5:44] == String(seq2)
+end # testset
+
+@testset "Copy! sequence" begin
+    function test_copy!(A, srctxt)
+        src = LongSequence{A}(srctxt)
+        dst = LongSequence{A}(0)
+        for len in [max(0, length(src) - 3), length(src), length(src) + 4]
+            resize!(dst, len)
+            copy!(dst, src)
+            @test String(dst) == String(src)
+        end
+    end
+
+    test_copy!(DNAAlphabet{4}, random_dna(14))
+    test_copy!(RNAAlphabet{2}, random_rna(55, [0.25, 0.25, 0.25, 0.25]))
+    test_copy!(AminoAcidAlphabet, random_aa(18))
+    test_copy!(CharAlphabet, random_aa(9))
+
+    #  Also works across nucleotide types!
+    for N in (2,4)
+        src = LongSequence{DNAAlphabet{N}}(random_dna(33, [0.25, 0.25, 0.25, 0.25]))
+        dst = LongSequence{RNAAlphabet{N}}(random_rna(31, [0.25, 0.25, 0.25, 0.25]))
+        copy!(dst, src)
+        @test String(typeof(dst)(src)) == String(dst)
+        resize!(dst, 16)
+        copy!(src, dst)
+        @test String(typeof(dst)(src)) == String(dst)
+    end
+
+    # Doesn't work for wrong types
+    @test_throws MethodError copy!(LongDNASeq("TAG"), LongAminoAcidSeq("WGM"))
+    @test_throws MethodError copy!(LongSequence{DNAAlphabet{2}}("TAG"), LongRNASeq("UGM"))
 end
 
-@testset "Encode copy!" begin
-    function test_encode_copy!(seq, src)
-        @test String(src) == String(BioSequences.encode_copy!(seq, src))
+@testset "Copyto! sequence" begin
+    function test_copyto!1(A1, dst, A2, src)
+        dst_ = LongSequence{A1}(dst)
+        src_ = LongSequence{A2}(src)
+        copyto!(dst_, src_)
+        @test String(src_) == String(dst_[1:length(src_)])
+    end
+
+    test_copyto!1(DNAAlphabet{4}, random_dna(19), DNAAlphabet{4}, random_dna(17))
+    test_copyto!1(RNAAlphabet{2}, random_rna(31, [0.25, 0.25, 0.25, 0.25]),
+                  RNAAlphabet{2}, random_rna(11, [0.25, 0.25, 0.25, 0.25]))
+    test_copyto!1(AminoAcidAlphabet, random_aa(61), AminoAcidAlphabet, random_aa(61))
+
+    function test_copyto2!(A, F)
+        for len in [10, 17, 51]
+            start = rand(1:3)
+            N = len - rand(1:4) - start
+            src = LongSequence{A}(F(len))
+            dst = LongSequence{A}(F(len))
+            copyto!(dst, start, src, start + 1, N)
+            @test String(dst[start:start+N-1]) == String(src[start+1:start+N])
+        end
+    end
+
+    test_copyto2!(DNAAlphabet{2}, len -> random_dna(len, [0.25, 0.25, 0.25, 0.25]))
+    test_copyto2!(RNAAlphabet{4}, random_rna)
+    test_copyto2!(AminoAcidAlphabet, random_aa)
+    test_copyto2!(CharAlphabet, random_aa)
+end
+
+@testset "Copy! data" begin
+    function test_copy!(seq, src)
+        @test String(src) == String(copy!(seq, src))
     end
     # Needed because conversion to String truncates vector.
-    function test_encode_copy!(seq, src::Vector)
-        @test String(copy(src)) == String(BioSequences.encode_copy!(copy(seq), src))
+    function test_copy!(seq, src::Vector)
+        @test String(copy(src)) == String(copy!(copy(seq), src))
     end
 
     probs = [0.25, 0.25, 0.25, 0.25, 0.00]
@@ -36,16 +99,72 @@ end
     charseq = LongSequence{CharAlphabet}(6)
     for dtype in [Vector{UInt8}, Vector{Char}, String, Test.GenericString]
         for len in [0, 1, 10, 16, 32, 100, 5]
-            test_encode_copy!(dna2, dtype(random_dna(len, probs)))
-            test_encode_copy!(dna4, dtype(random_dna(len)))
-            test_encode_copy!(rna2, dtype(random_rna(len, probs)))
-            test_encode_copy!(rna4, dtype(random_rna(len)))
-            test_encode_copy!(aa, dtype(random_aa(len)))
-            test_encode_copy!(charseq, dtype(random_aa(len)))
+            test_copy!(dna2, dtype(random_dna(len, probs)))
+            test_copy!(dna4, dtype(random_dna(len)))
+            test_copy!(rna2, dtype(random_rna(len, probs)))
+            test_copy!(rna4, dtype(random_rna(len)))
+            test_copy!(aa, dtype(random_aa(len)))
+            test_copy!(charseq, dtype(random_aa(len)))
         end
     end
-    test_encode_copy!(charseq, "ϐʌ⨝W")
+    test_copy!(charseq, "ϐʌ⨝W")
 end
+
+@testset "Copyto! data" begin
+    function test_twoarg_copyto!(seq, src)
+        copyto!(seq, src)
+        @test String(src[1:length(src)]) == String(src)
+    end
+    # Needed because conversion to String truncates vector.
+    function test_twoarg_copyto!(seq, src::Vector)
+        copyto!(seq, src)
+        @test String(src[1:length(src)]) == String(copy(src))
+    end
+
+    probs = [0.25, 0.25, 0.25, 0.25, 0.00]
+    dna2 = LongSequence{DNAAlphabet{2}}(50)
+    dna4 = LongSequence{DNAAlphabet{4}}(50)
+    rna2 = LongSequence{RNAAlphabet{2}}(50)
+    rna4 = LongSequence{RNAAlphabet{4}}(50)
+    aa = LongSequence{AminoAcidAlphabet}(50)
+    charseq = LongSequence{CharAlphabet}(50)
+    for dtype in [Vector{UInt8}, Vector{Char}, String, Test.GenericString]
+        for len in [0, 1, 10, 16, 32, 5]
+            test_twoarg_copyto!(dna2, dtype(random_dna(len, probs)))
+            test_twoarg_copyto!(dna4, dtype(random_dna(len)))
+            test_twoarg_copyto!(rna2, dtype(random_rna(len, probs)))
+            test_twoarg_copyto!(rna4, dtype(random_rna(len)))
+            test_twoarg_copyto!(aa, dtype(random_aa(len)))
+            test_twoarg_copyto!(charseq, dtype(random_aa(len)))
+        end
+    end
+    copyto!(charseq, "ϐʌ⨝W")
+    @test collect(charseq[1:4]) == collect("ϐʌ⨝W")
+
+    # Five-arg copyto!
+    function test_fivearg_copyto!(seq, src)
+        for soff in (1, 3)
+            for doff in (1, 5)
+                for N in (0, 5, 18, 30)
+                    copyto!(seq, doff, src, soff, N)
+                    @test String(seq[doff:doff+N-1]) == String(src[soff:soff+N-1])
+                end
+            end
+        end
+    end
+
+    for dtype in [Vector{UInt8}, Vector{Char}, String, Test.GenericString]
+        test_fivearg_copyto!(dna2, dtype(random_dna(60, probs)))
+        test_fivearg_copyto!(dna4, dtype(random_dna(60)))
+        test_fivearg_copyto!(rna2, dtype(random_rna(60, probs)))
+        test_fivearg_copyto!(rna4, dtype(random_rna(60)))
+        test_fivearg_copyto!(aa, dtype(random_aa(60)))
+        test_fivearg_copyto!(charseq, dtype(random_aa(60)))
+    end
+
+end
+
+################
 
 @testset "Concatenation" begin
     function test_concatenation(A, chunks)

--- a/test/longsequences/conversion.jl
+++ b/test/longsequences/conversion.jl
@@ -90,31 +90,31 @@ end
 @testset "Encode_copy!" begin
     # Note: Other packages use this function, so we need to test it
     # Even though this is NOT exported or part of the API in a normal sense
-    function test_encode_copy(dst::LongSequence{}, doff, src, soff, N)
-        BioSequences.encode_copyto!(dst, doff, src, soff, N)
+    function test_copyto!(dst::LongSequence{}, doff, src, soff, N)
+        BioSequences.copyto!(dst, doff, src, soff, N)
         @test String(dst[doff:doff+N-1]) == String(src[soff:soff+N-1])
     end
 
     probs = [0.25, 0.25, 0.25, 0.25]
     for len in [0, 1, 2, 10, 100]
         for f in [identity, Vector{Char}, Vector{UInt8}]
-            test_encode_copy(LongSequence{DNAAlphabet{2}}(len), 1, f(random_dna(len, probs)), 1, len)
-            test_encode_copy(LongSequence{RNAAlphabet{2}}(len), 1, f(random_rna(len, probs)), 1, len)
-            test_encode_copy(LongSequence{DNAAlphabet{4}}(len), 1, f(random_dna(len)), 1, len)
-            test_encode_copy(LongSequence{RNAAlphabet{4}}(len), 1, f(random_rna(len)), 1, len)
-            test_encode_copy(LongSequence{AminoAcidAlphabet}(len), 1, f(random_aa(len)), 1, len)
-            test_encode_copy(LongSequence{CharAlphabet}(len), 1, f(random_aa(len)), 1, len)
+            test_copyto!(LongSequence{DNAAlphabet{2}}(len), 1, f(random_dna(len, probs)), 1, len)
+            test_copyto!(LongSequence{RNAAlphabet{2}}(len), 1, f(random_rna(len, probs)), 1, len)
+            test_copyto!(LongSequence{DNAAlphabet{4}}(len), 1, f(random_dna(len)), 1, len)
+            test_copyto!(LongSequence{RNAAlphabet{4}}(len), 1, f(random_rna(len)), 1, len)
+            test_copyto!(LongSequence{AminoAcidAlphabet}(len), 1, f(random_aa(len)), 1, len)
+            test_copyto!(LongSequence{CharAlphabet}(len), 1, f(random_aa(len)), 1, len)
         end
     end
 
     for len in [10, 32, 100]
         for f in [identity, Vector{Char}, Vector{UInt8}]
-            test_encode_copy(LongSequence{DNAAlphabet{2}}(len+7), 5, f(random_dna(len+11, probs)), 3, len)
-            test_encode_copy(LongSequence{RNAAlphabet{2}}(len+7), 5, f(random_rna(len+11, probs)), 3, len)
-            test_encode_copy(LongSequence{DNAAlphabet{4}}(len+7), 5, f(random_dna(len+11)), 3, len)
-            test_encode_copy(LongSequence{RNAAlphabet{4}}(len+7), 5, f(random_rna(len+11)), 3, len)
-            test_encode_copy(LongSequence{AminoAcidAlphabet}(len+7), 5, f(random_aa(len+11)), 3, len)
-            test_encode_copy(LongSequence{CharAlphabet}(len+7), 5, f(random_aa(len+11)), 3, len)
+            test_copyto!(LongSequence{DNAAlphabet{2}}(len+7), 5, f(random_dna(len+11, probs)), 3, len)
+            test_copyto!(LongSequence{RNAAlphabet{2}}(len+7), 5, f(random_rna(len+11, probs)), 3, len)
+            test_copyto!(LongSequence{DNAAlphabet{4}}(len+7), 5, f(random_dna(len+11)), 3, len)
+            test_copyto!(LongSequence{RNAAlphabet{4}}(len+7), 5, f(random_rna(len+11)), 3, len)
+            test_copyto!(LongSequence{AminoAcidAlphabet}(len+7), 5, f(random_aa(len+11)), 3, len)
+            test_copyto!(LongSequence{CharAlphabet}(len+7), 5, f(random_aa(len+11)), 3, len)
         end
     end
 end

--- a/test/longsequences/conversion.jl
+++ b/test/longsequences/conversion.jl
@@ -91,12 +91,8 @@ end
     # Note: Other packages use this function, so we need to test it
     # Even though this is NOT exported or part of the API in a normal sense
     function test_encode_copy(dst::LongSequence{}, doff, src, soff, N)
-        BioSequences.encode_copy!(dst, doff, src, soff, N)
+        BioSequences.encode_copyto!(dst, doff, src, soff, N)
         @test String(dst[doff:doff+N-1]) == String(src[soff:soff+N-1])
-    end
-    function test_encode_copy(dst::LongSequence{}, doff, src, soff)
-        BioSequences.encode_copy!(dst, doff, src, soff)
-        @test String(dst[doff:end]) == String(src[soff:end])
     end
 
     probs = [0.25, 0.25, 0.25, 0.25]
@@ -119,10 +115,6 @@ end
             test_encode_copy(LongSequence{RNAAlphabet{4}}(len+7), 5, f(random_rna(len+11)), 3, len)
             test_encode_copy(LongSequence{AminoAcidAlphabet}(len+7), 5, f(random_aa(len+11)), 3, len)
             test_encode_copy(LongSequence{CharAlphabet}(len+7), 5, f(random_aa(len+11)), 3, len)
-
-            # Test some specific methods only used in dispatch
-            test_encode_copy(LongSequence{DNAAlphabet{2}}(len+7), 5, f(random_dna(len+5, probs)), 3)
-            test_encode_copy(LongSequence{RNAAlphabet{4}}(len+7), 5, f(random_rna(len+5)), 3)
         end
     end
 end

--- a/test/longsequences/mutability.jl
+++ b/test/longsequences/mutability.jl
@@ -145,7 +145,7 @@
         @test copyto!(seq, dna"TTA") == dna"TTA"
 
         seq = dna"TCCC"
-        @test copyto!(seq, 2, dna"TT", 1) == dna"TTTC"
+        @test copyto!(seq, 2, dna"TT", 1, 2) == dna"TTTC"
         seq = dna"TCCC"
         @test copyto!(seq, 2, dna"TT", 1, 1) == dna"TTCC"
 


### PR DESCRIPTION
# Revamb copy! and copyto! interface

As briefly discussed in https://github.com/BioJulia/BioSequences.jl/pull/92#issuecomment-575890467, but this PR is a little broader in scope.

**Note: This PR may be breaking, DO NOT MERGE until we settle the correct interface**. I'm not entirely sure what functions are considered part of the BioSequences interface, since none of them were documented.

### New API
The new API is built on three principles:
1) It should mirror `Base.copy!` and `Base.copyto!` on arrays.
2) Only biological symbols with compatible alphabets should be copied to each other using `copy!` and `copyto!`. Currently, my idea are that only the following alphabet pairs are compatible:
* Any alphabet and itself
* NucleotideAlphabet{N} and NucleotideAlphabet{N}
* NucleotideAlphabet{2} as source and NucleotideAlphabet{4} as destination
* ReferenceSequence as source and NucleotideAlphabet{4} as destination.
* NucleotideAlphabet{2} as source and ReferenceSequence as destination

These implies that DNA and RNA can be used interchangably.
To copy non-BioSequence types to a BioSequence, the user needs to specify that they also need to encode the data by calling e.g. `encode_copyto!` instead of `copyto!`. The two `encode_*` functions should take the same arguments as the non-encoding ones and do the same.

3) They should be fast by default _where we care to make special case optimizations_.

Mirroring `copy!` and `copyto!`, for the encoding functions, only the following three methods should be exposed for the encoding and the non-encoding:
1) `copy!(dst, src)`, which resizes `dst` to fit, then copies all data from `src` to `dst`.
2) `copyto!(dst, src)`, which behaves identically to `copyto!(dst, 1, src, 1, length(src))`
3) `copyto!(dst, doff, src, soff, N)`, which copies N elements of `src` starting at `soff` to `dst` starting at `doff`, leaving the rest of `dst` unchanged. If there is not enough elements in `src` or `dst`, throw an error.

### Discussion
* What is breaking in this API? Were all these functions internal before? We can add in any missing `copyto!` methods we need to keep any of the old API if it is still needed.
* Is it even useful to separate encoding and non-encoding functions, or should we just merge them in one? After all, the difference between them is exactly the type of their inputs, meaning it may be more Julian to have them as different methods of same type.
* Should there be a generic fallback for the copying methods that attempts to copy elements without regard for alphabet compatibility? Maybe there should.

### TODO
* Export `encode_copy!` and `encode_copyto!` functions
* Add generic methods in `src/biosequences` for `copy!` and `copyto!`
* Add lots of tests for all exported functions.