### PR TITLE
Improve performance of bit-parallel counting methods

### DIFF
--- a/src/bit-manipulation/bitpar-compiler.jl
+++ b/src/bit-manipulation/bitpar-compiler.jl
@@ -28,14 +28,8 @@ function compile_bitpar(funcname::Symbol;
                 chunk = (data[index(ind)] >> o) & bitmask(stop - ind)
                 $(head_code)
                 ind += 64 - o
-                @assert offset(ind) == 0
+                #@assert offset(ind) == 0
             end
-            
-            #while i ≤ stop - 64
-            #    chunk = seq.data[index(i)]
-            #    $(body_code)
-            #    i += 64
-            #end
             
             lastind = index(stop - bits_per_symbol(seq))
             lastind -= !iszero(offset(stop))

--- a/src/bit-manipulation/bitpar-compiler.jl
+++ b/src/bit-manipulation/bitpar-compiler.jl
@@ -28,7 +28,6 @@ function compile_bitpar(funcname::Symbol;
                 chunk = (data[index(ind)] >> o) & bitmask(stop - ind)
                 $(head_code)
                 ind += 64 - o
-                #@assert offset(ind) == 0
             end
             
             lastind = index(stop - bits_per_symbol(seq))

--- a/src/bit-manipulation/bitpar-compiler.jl
+++ b/src/bit-manipulation/bitpar-compiler.jl
@@ -40,6 +40,7 @@ function compile_bitpar(funcname::Symbol;
             lastind = index(stop - bits_per_symbol(seq))
             lastind -= !iszero(offset(stop))
             for i in index(ind):lastind
+                chunk = data[i]
                 $(body_code)
                 ind += 64
             end

--- a/src/bit-manipulation/bitpar-compiler.jl
+++ b/src/bit-manipulation/bitpar-compiler.jl
@@ -18,24 +18,34 @@ function compile_bitpar(funcname::Symbol;
     end
     functioncode.args[2] = quote
         $(init_code)
-        i = bitindex(seq, 1)
+        ind = bitindex(seq, 1)
         stop = bitindex(seq, lastindex(seq) + 1)
+        data = seq.data
         @inbounds begin
-            if offset(i) != 0 && i < stop
+            if !iszero(offset(ind)) & (ind < stop)
                 # align the bit index to the beginning of a block boundary
-                o = offset(i)
-                chunk = (seq.data[index(i)] >> o) & bitmask(stop - i)
+                o = offset(ind)
+                chunk = (data[index(ind)] >> o) & bitmask(stop - ind)
                 $(head_code)
-                i += 64 - o
-                @assert offset(i) == 0
+                ind += 64 - o
+                @assert offset(ind) == 0
             end
-            while i ≤ stop - 64
-                chunk = seq.data[index(i)]
+            
+            #while i ≤ stop - 64
+            #    chunk = seq.data[index(i)]
+            #    $(body_code)
+            #    i += 64
+            #end
+            
+            lastind = index(stop - bits_per_symbol(seq))
+            lastind -= !iszero(offset(stop))
+            for i in index(ind):lastind
                 $(body_code)
-                i += 64
+                ind += 64
             end
-            if i < stop
-                chunk = seq.data[index(i)] & bitmask(offset(stop))
+            
+            if ind < stop
+                chunk = data[index(ind)] & bitmask(offset(stop))
                 $(tail_code)
             end
         end

--- a/src/longsequences/counting.jl
+++ b/src/longsequences/counting.jl
@@ -69,19 +69,23 @@ Base.count(::typeof(==), seqa::LongNucleotideSequence, seqb::LongNucleotideSeque
 
 # Counting ambiguous sites
 let
-    @info "Compiling bit-parallel ambiguity counter for LongSequence{<:NucleicAcidAlphabet}"
+    @info "Compiling bit-parallel ambiguity counter..."
+    @info "\tFor a single LongSequence{<:NucleicAcidAlphabet}"
     
     counter = :(count += ambiguous_bitcount(x, y, A()))
+    counterb = :(count += ambiguous_bitcount(chunk, Alphabet(seq)))
     
     compile_bitpar(
         :count_ambiguous_bitpar,
         arguments   = (:(seq::LongSequence{<:NucleicAcidAlphabet}),),
         init_code   = :(count = 0),
-        head_code   = counter,
-        body_code   = counter,
-        tail_code   = counter,
+        head_code   = counterb,
+        body_code   = counterb,
+        tail_code   = counterb,
         return_code = :(return count)
     ) |> eval
+    
+    @info "\tFor a pair of LongSequence{<:NucleicAcidAlphabet}s"
     
     compile_2seq_bitpar(
         :count_ambiguous_bitpar,

--- a/src/longsequences/counting.jl
+++ b/src/longsequences/counting.jl
@@ -73,6 +73,16 @@ let
     
     counter = :(count += ambiguous_bitcount(x, y, A()))
     
+    compile_bitpar(
+        :count_ambiguous_bitpar,
+        arguments   = (:(seq::LongSequence{<:NucleicAcidAlphabet}),),
+        init_code   = :(count = 0),
+        head_code   = counter,
+        body_code   = counter,
+        tail_code   = counter,
+        return_code = :(return count)
+    ) |> eval
+    
     compile_2seq_bitpar(
         :count_ambiguous_bitpar,
         arguments = (:(seqa::LongSequence{A}), :(seqb::LongSequence{A})),


### PR DESCRIPTION
This PR aims to fix some of the observations from the performance review #86 

Notably:

- [x] Slow GC counting in bit parallel mode.
- [x] Lack of bit-parallel single sequence counting mode for ambiguous nucleotides.


Benchmarks prior to changes:

```julia
julia> using BioSequences, BenchmarkTools
julia> s = randdnaseq(100_000)
julia> s2 = LongSequence{DNAAlphabet{2}}(s)

julia> @benchmark count(isGC, s)
BenchmarkTools.Trial: 
  memory estimate:  16 bytes
  allocs estimate:  1
  --------------
  minimum time:     8.385 μs (0.00% GC)
  median time:      8.499 μs (0.00% GC)
  mean time:        8.784 μs (0.00% GC)
  maximum time:     29.168 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     3

julia> @benchmark count(isGC, s2)
BenchmarkTools.Trial: 
  memory estimate:  16 bytes
  allocs estimate:  1
  --------------
  minimum time:     2.723 μs (0.00% GC)
  median time:      2.746 μs (0.00% GC)
  mean time:        2.829 μs (0.00% GC)
  maximum time:     8.697 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     9

julia> @benchmark count(isambiguous, s)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     114.989 μs (0.00% GC)
  median time:      119.960 μs (0.00% GC)
  mean time:        136.786 μs (0.00% GC)
  maximum time:     413.966 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark count(isambiguous, s2)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     133.609 μs (0.00% GC)
  median time:      136.452 μs (0.00% GC)
  mean time:        144.586 μs (0.00% GC)
  maximum time:     407.740 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```