### PR TITLE
Faster reverse and reverse complement

### DIFF
--- a/test/longsequences/mutability.jl
+++ b/test/longsequences/mutability.jl
@@ -72,6 +72,9 @@
         @test length(seq) == 100
         resize!(seq, 200)
         @test length(seq) == 200
+        seq1 = seq[3:198]
+        resize!(seq1, 55)
+        @test length(seq1) == 55
         resize!(seq,  10)
         @test length(seq) == 10
         @test_throws ArgumentError resize!(seq, -1)

--- a/test/longsequences/transformations.jl
+++ b/test/longsequences/transformations.jl
@@ -2,6 +2,8 @@
     function test_reverse(A, seq)
         revseq = reverse(LongSequence{A}(seq))
         @test convert(String, revseq) == reverse(seq)
+        revseq = reverse!(LongSequence{A}(seq))
+        @test convert(String, revseq) == reverse(seq)
     end
 
     function test_dna_complement(A, seq)


### PR DESCRIPTION
As mentioned in https://github.com/BioJulia/BioSequences.jl/issues/86#issuecomment-579644631.

Improves reversion, complementation and reverse-complement of nucleotides.

This PR needs some more tests, please do not merge it. I will merge it when it has complete coverage.

I think I'm done optimizing this part for now. At 12 µs for a 1 mill nucleotide sequence, I can't possibly think anyone would want it faster.

Edit: Note to self: I should also add more comments in the code.