### PR TITLE
Added fast hashing for kmers

### DIFF
--- a/src/mers/predicates.jl
+++ b/src/mers/predicates.jl
@@ -5,3 +5,7 @@
 Base.cmp(seq1::T, seq2::T) where {T<:AbstractMer} = cmp(encoded_data(seq1), encoded_data(seq2))
 Base.:(==)(x::T, y::T) where {T<:AbstractMer} = encoded_data(x) == encoded_data(y)
 Base.isless(x::T, y::T) where {T<:AbstractMer} = isless(encoded_data(x), encoded_data(y))
+
+function Base.hash(x::Mer{<:NucleicAcidAlphabet{2},K}, h::UInt) where {K}
+    return Base.hash_uint64(encoded_data(x) ⊻ K ⊻ h)
+end


### PR DESCRIPTION
This is a very simple PR. Currently, `hash` is not defined for Mers, which makes it default to a slow version. This PR simply adds:
```
function Base.hash(x::Mer{<:Union{DNAAlphabet{N}, RNAAlphabet{N}},K}, h::UInt) where {N,K}
    return Base.hash_uint64(encoded_data(x) ⊻ K ⊻ N)
end
```
It makes e.g. minhashing significantly faster.

It would be nice to have a version that works for ALL mers. The problem is that the hash should depend on both the alphabet type and the mer length, _and_ that these values should constant fold. I don't know how to do this for any alphabet.
