### PR TITLE
Fix reverse_complement orphan bug

### DIFF
--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -159,6 +159,7 @@ function complement!(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
 end
 
 function reverse_complement!(seq::LongSequence{<:NucleicAcidAlphabet})
+    orphan!(seq)
     pred = x -> complement_bitpar(x, Alphabet(seq))
     reverse_data!(pred, seq.data, BitsPerSymbol(seq))
     return zero_offset!(seq)

--- a/test/longsequences/transformations.jl
+++ b/test/longsequences/transformations.jl
@@ -73,6 +73,18 @@
         seq_string = join(rand("-ACGUSWKMYRBDHVN", 1000))
         seq = reverse_complement(LongSequence{RNAAlphabet{4}}(seq_string))
         @test String(seq) == reverse(rna_complement(seq_string))
+
+        seq_string = join(rand("-ACGTSWKMYRBDHVN", 1000))
+        seq = reverse_complement!(LongSequence{DNAAlphabet{4}}(seq_string))
+        @test String(seq) == reverse(dna_complement(seq_string))
+
+        seq_string = join(rand("-ACGTSWKMYRBDHVN", 1000))
+        seq = LongSequence{DNAAlphabet{4}}(seq_string)
+        seq2 = seq[100:200]
+        reverse_complement!(seq2)
+        @test String(seq) == seq_string
+        @test String(seq2) == reverse(dna_complement(seq_string[100:200]))
+
     end
 
     @testset "Map" begin


### PR DESCRIPTION
This fixes a bug I introduced when I rewrote the `reverse_complement!` of `LongSequence`s. I just forgot to insert an `orphan!` call.