### PR TITLE
Use stable RNG (take two)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 IndexableBitVectors = "1cb3b9ac-1ffd-5777-9e6b-a3d42300664d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Twiddle = "7200193e-83a8-5a55-b20d-5d36d44a0795"
 
 [compat]

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -266,6 +266,7 @@ import Twiddle: enumerate_nibbles,
     count_nonzero_bitpairs,
     repeatpattern
 using Random
+using StableRNGs
 
 BioSymbols.gap(::Type{Char}) = '-'
 

--- a/test/longsequences/randseq.jl
+++ b/test/longsequences/randseq.jl
@@ -7,14 +7,14 @@ struct MyAlphabet <: Alphabet end
 
 @testset "Random LongSequences" begin
 function test_sampler(sampler, seed, elements, firstten, T)
-    rng = MersenneTwister(seed)
+    rng = StableRNG(seed)
     sampled1 = [rand(rng, sampler) for i in 1:1000]
-    sampled2 = rand(MersenneTwister(seed), sampler, 1000)
+    sampled2 = rand(StableRNG(seed), sampler, 1000)
     @test sampled1 == sampled2
     @test Set(sampled1) == Set(T[convert(T, i) for i in elements])
     @test eltype(sampler) == T
     @test eltype(firstten) == T
-    @test rand(MersenneTwister(seed), sampler, 10) == firstten
+    @test rand(StableRNG(seed), sampler, 10) == firstten
 end
 
 function test_isseq(seq, alphabettype, len)
@@ -28,11 +28,11 @@ end
 
     # DNA sampler with DNA array
     sampler = SamplerUniform{DNA}([DNA_A, DNA_C, DNA_G, DNA_W])
-    firstten = DNA[DNA_A, DNA_G, DNA_C, DNA_C, DNA_A, DNA_G, DNA_A, DNA_W, DNA_W, DNA_A]
+    firstten = DNA[DNA_C, DNA_W, DNA_G, DNA_C, DNA_C, DNA_C, DNA_C, DNA_A, DNA_A, DNA_A]
     test_sampler(sampler, SEED, sampler.elems, firstten, DNA)
     # Now RNA sampler from DNA array
     sampler = SamplerUniform{RNA}([DNA_A, DNA_C, DNA_G, DNA_W])
-    firstten = RNA[RNA_A, RNA_G, RNA_C, RNA_C, RNA_A, RNA_G, RNA_A, RNA_W, RNA_W, RNA_A]
+    firstten = RNA[RNA_C, RNA_W, RNA_G, RNA_C, RNA_C, RNA_C, RNA_C, RNA_A, RNA_A, RNA_A]
     test_sampler(sampler, SEED, sampler.elems, firstten, RNA)
 
     # Cannot make AA sampler from DNA
@@ -78,11 +78,11 @@ end # SamplerUniform
     @test sum(s.probs) == 1.0
 
     sampler = SamplerWeighted{DNA}([DNA_N, DNA_C, DNA_W, DNA_T], [0.1, 0.2, 0.3])
-    firstten = DNA[DNA_T, DNA_T, DNA_C, DNA_C, DNA_C, DNA_C, DNA_N, DNA_N, DNA_W, DNA_T]
+    firstten = DNA[DNA_C, DNA_N, DNA_T, DNA_T, DNA_T, DNA_N, DNA_W, DNA_C, DNA_W, DNA_N]
     test_sampler(sampler, 0, sampler.elems, firstten, DNA)
 
     sampler = SamplerWeighted{RNA}([DNA_N, DNA_C, DNA_W, DNA_T], [0.15, 0.5, 0.2])
-    firstten = RNA[RNA_W, RNA_U, RNA_C, RNA_C, RNA_C, RNA_C, RNA_N, RNA_N, RNA_C, RNA_U]
+    firstten = RNA[RNA_C, RNA_N, RNA_U, RNA_W, RNA_U, RNA_N, RNA_C, RNA_C, RNA_C, RNA_N]
     test_sampler(sampler, 0, sampler.elems, firstten, RNA)
 
     @test_throws MethodError s = SamplerWeighted{AminoAcid}([DNA_A, DNA_C], [0.1])
@@ -110,13 +110,13 @@ end # SamplerWeighted
 
     # A few samplings
     sampler = SamplerUniform(aa"TVVWYAEDK")
-    @test randseq(MersenneTwister(SEED), AminoAcidAlphabet(), sampler, 10) == aa"TVATTWKDAD"
+    @test randseq(StableRNG(SEED), AminoAcidAlphabet(), sampler, 10) == aa"VEVTKTTADY"
 
     sampler = SamplerUniform(dna"TGAWYKN")
-    @test randseq(MersenneTwister(SEED), DNAAlphabet{4}(), sampler, 10) == dna"TAGKTATWTK"
+    @test randseq(StableRNG(SEED), DNAAlphabet{4}(), sampler, 10) == dna"GWNGGGKTTT"
 
     sampler = SamplerWeighted(rna"UGCMKYN", [0.1, 0.05, 0.2, 0.15, 0.15, 0.2])
-    @test randseq(MersenneTwister(SEED), DNAAlphabet{4}(), sampler, 10) == dna"YNCCCCTTMN"
+    @test randseq(StableRNG(SEED), DNAAlphabet{4}(), sampler, 10) == dna"CTNYNTKCMT"
 
     # Casual tests to see that it can use the global RNG automatically
     sampler = SamplerUniform(aa"TVVWYAEDK")
@@ -134,16 +134,16 @@ end # randseq Sampler
 
 @testset "randseq" begin
     sampler = SamplerUniform(aa"ACDEFGHIKLMNPQRSTVWY")
-    automatic = randseq(MersenneTwister(SEED), AminoAcidAlphabet(), 1000)
-    manual = randseq(MersenneTwister(SEED), AminoAcidAlphabet(), sampler, 1000)
+    automatic = randseq(StableRNG(SEED), AminoAcidAlphabet(), 1000)
+    manual = randseq(StableRNG(SEED), AminoAcidAlphabet(), sampler, 1000)
     @test automatic == manual
     @test Set(automatic) == Set(aa"ACDEFGHIKLMNPQRSTVWY")
 
-    @test randseq(MersenneTwister(SEED), DNAAlphabet{4}(), 20) == dna"AAGATCGGTTCATCCTCAAA"
-    @test randseq(MersenneTwister(SEED), DNAAlphabet{2}(), 20) == dna"TTCGGGATGACTATCTCAGA"
+    @test randseq(StableRNG(SEED), DNAAlphabet{4}(), 20) == dna"CTCTTCGTATGCCGTACCGT"
+    @test randseq(StableRNG(SEED), DNAAlphabet{2}(), 20) == dna"CATCCGCTCCTAGGCCATTT"
 
-    @test randseq(MersenneTwister(SEED), RNAAlphabet{4}(), 20) == rna"AAGAUCGGUUCAUCCUCAAA"
-    @test randseq(MersenneTwister(SEED), RNAAlphabet{2}(), 20) == rna"UUCGGGAUGACUAUCUCAGA"
+    @test randseq(StableRNG(SEED), RNAAlphabet{4}(), 20) == rna"CUCUUCGUAUGCCGUACCGU"
+    @test randseq(StableRNG(SEED), RNAAlphabet{2}(), 20) == rna"CAUCCGCUCCUAGGCCAUUU"
 
     # Casual tests to see that it can use the global RNG automatically
     seq = randseq(DNAAlphabet{2}(), 100)
@@ -157,16 +157,16 @@ end # randseq Sampler
 end # randseq
 
 @testset "Simple constructors" begin
-    manual = randseq(MersenneTwister(SEED), AminoAcidAlphabet(), 100)
-    automatic = randaaseq(MersenneTwister(SEED), 100)
+    manual = randseq(StableRNG(SEED), AminoAcidAlphabet(), 100)
+    automatic = randaaseq(StableRNG(SEED), 100)
     @test automatic == manual
 
-    manual = randseq(MersenneTwister(SEED), DNAAlphabet{4}(), 100)
-    automatic = randdnaseq(MersenneTwister(SEED), 100)
+    manual = randseq(StableRNG(SEED), DNAAlphabet{4}(), 100)
+    automatic = randdnaseq(StableRNG(SEED), 100)
     @test automatic == manual
 
-    manual = randseq(MersenneTwister(SEED), RNAAlphabet{4}(), 100)
-    automatic = randrnaseq(MersenneTwister(SEED), 100)
+    manual = randseq(StableRNG(SEED), RNAAlphabet{4}(), 100)
+    automatic = randrnaseq(StableRNG(SEED), 100)
     @test automatic == manual
 
     # Casual tests to see that it can use the global RNG automatically

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ module TestBioSequences
 
 using Test
 using Random
+using StableRNGs
 using LinearAlgebra: normalize
 import BioSymbols
 using BioSequences


### PR DESCRIPTION
Resolves #77 (take two, I messed up my branches on the other one)

This uses StableRNGs. With its simple implementation, stable RNGs are slower than Julia's default, meaning that this PR slightly slows down random seq generation. However, I think the slowdown and additional dependency is worth it to guarantee reproducible random sequences across major BioJulia versions.

@kescobo I still don't know how to properly add dependencies to Julia projects. Could you please check if the `Project.toml` is correct? In particular, do I need to add something to the compat part?

For comparison, here are some simple benchmarks when creating sequences of length 10,000:
```
                        before ns    after ns
NucleicAcidAlphabet{2}   521           390
NucleicAcidAlphabet{4}  7440           873
AminoAcidAlphabet      62700         92114
SamplerUniform         61440         62700
SamplerWeighted        79000         83000
```

So yeah, the effect is pretty minor, and it's even faster for random nucleotide generation.