### PR TITLE
Fixup addition with a BitIndex

### DIFF
--- a/src/bit-manipulation/bitindex.jl
+++ b/src/bit-manipulation/bitindex.jl
@@ -31,8 +31,8 @@ offset_mask(i::BitIndex{N, W}) where {N, W} = UInt8(8 * sizeof(W)) - 0x01
 index(i::BitIndex) = (i.val >> index_shift(i)) + 1
 offset(i::BitIndex) = i.val & offset_mask(i)
 
-Base.:+(i::BitIndex{N,W}, n::Int) where {N,W} = BitIndex{N,W}(i.val + n)
-Base.:-(i::BitIndex{N,W}, n::Int) where {N,W} = BitIndex{N,W}(i.val - n)
+Base.:+(i::BitIndex{N,W}, n::Integer) where {N,W} = BitIndex{N,W}(i.val + n)
+Base.:-(i::BitIndex{N,W}, n::Integer) where {N,W} = BitIndex{N,W}(i.val - n)
 Base.:-(i1::BitIndex, i2::BitIndex) = i1.val - i2.val
 Base.:(==)(i1::BitIndex, i2::BitIndex) = i1.val == i2.val
 Base.isless(i1::BitIndex, i2::BitIndex) = isless(i1.val, i2.val)


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [X] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

There are cases that can occur in `copyto!` methods where depending on how the arithmetic to compute increments of BitIndex go - if they return a UInt and try to do the addition with the BitIndex, then there is a method error. This is because addition of a number to a BitIndex is only defined for `BitIndex + Int`, but really to make sure stuff like this does not crop up I've edited the + and - methods to work for `BitIndex & Integer`, which permits both signed and unsigned integers.