### PR TITLE
hotfix for reverse_complementing a slice of a longseq

### DIFF
--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -166,6 +166,7 @@ function reverse_complement!(seq::LongSequence{<:NucleicAcidAlphabet})
 end
 
 function reverse_complement(seq::LongSequence{<:NucleicAcidAlphabet})
+    orphan!(seq)
     cp = typeof(seq)(unsigned(length(seq)))
     pred = x -> complement_bitpar(x, Alphabet(seq))
     reverse_data_copy!(pred, cp.data, seq.data, BitsPerSymbol(seq))

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -166,11 +166,7 @@ function reverse_complement!(seq::LongSequence{<:NucleicAcidAlphabet})
 end
 
 function reverse_complement(seq::LongSequence{<:NucleicAcidAlphabet})
-    orphan!(seq)
-    cp = typeof(seq)(unsigned(length(seq)))
-    pred = x -> complement_bitpar(x, Alphabet(seq))
-    reverse_data_copy!(pred, cp.data, seq.data, BitsPerSymbol(seq))
-    return zero_offset!(cp)
+    return reverse_complement!(copy(seq))
 end
 
 ###

--- a/test/longsequences/transformations.jl
+++ b/test/longsequences/transformations.jl
@@ -85,6 +85,8 @@
         @test String(seq) == seq_string
         @test String(seq2) == reverse(dna_complement(seq_string[100:200]))
 
+	slice = randdnaseq(10)[2:9]
+	@test reverse_complement(reverse_complement(slice)) == slice
     end
 
     @testset "Map" begin


### PR DESCRIPTION
There's probably a more performant fix but this seems to do the job as a patch

https://github.com/BioJulia/BioSequences.jl/issues/110
https://github.com/BioJulia/FASTX.jl/issues