### PR TITLE
Implement range slices over kmers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Ability to take a slice of an AbstractMer over a range
 
 ## [2.0.1]
 ### Changed

--- a/src/mers/indexing.jl
+++ b/src/mers/indexing.jl
@@ -10,3 +10,9 @@
     return reinterpret(eltype(x), 0x01 << ((encoded_data(x) >> offset(x, i)) & 0b11))
 end
 
+function Base.getindex(mer::T, r::OrdinalRange{<:Integer, <:Integer}) where {A,K,T<:AbstractMer{A,K}}
+    parameterless_mer_type = Base.typename(T).wrapper
+    new_K = length(r)
+    new_T = parameterless_mer_type{A, new_K}
+    return new_T(mer[i] for i in r)
+end

--- a/test/mers/access.jl
+++ b/test/mers/access.jl
@@ -112,12 +112,11 @@
 	RNAMer("ACGU")[2:3] == RNAMer("CG")
 	BigRNAMer("ACGU")[2:3] == BigRNAMer("CG")
 
-	# ordinal range
 	DNAMer("ACGT")[2:1:3] == DNAMer("CG")
-	# empty range
-	@test_throws ArgumentError DNAMer("ACGT")[3:2]
-	# works if step is declared
+	DNAMer("ACGT")[1:2:end] == DNAMer("CG")
 	DNAMer("ACGT")[3:-1:2] == DNAMer("GC")
+
+	@test_throws ArgumentError DNAMer("ACGT")[3:2]
 	@test_throws BoundsError DNAMer("ACGT")[3:5]
     end
 end

--- a/test/mers/access.jl
+++ b/test/mers/access.jl
@@ -105,4 +105,20 @@
         @test all([nt === rna_vec[i] for (i, nt) in enumerate(rna_kmer)])
         @test all([nt === rna_vec[i] for (i, nt) in enumerate(big_rna_kmer)])
     end
+
+    @testset "Take slices of Mers" begin
+	import BioSequences
+	BioSequences.DNAMer("ACGT")[2:3] == BioSequences.DNAMer("CG")
+	BioSequences.BigDNAMer("ACGT")[2:3] == BioSequences.BigDNAMer("CG")
+	BioSequences.RNAMer("ACGU")[2:3] == BioSequences.RNAMer("CG")
+	BioSequences.BigRNAMer("ACGU")[2:3] == BioSequences.BigRNAMer("CG")
+
+	# ordinal range
+	BioSequences.DNAMer("ACGT")[2:1:3] == BioSequences.DNAMer("CG")
+	# empty range
+	Test.@test_throws ArgumentError BioSequences.DNAMer("ACGT")[3:2]
+	# works if step is declared
+	BioSequences.DNAMer("ACGT")[3:-1:2] == BioSequences.DNAMer("GC")
+	Test.@test_throws BoundsError BioSequences.DNAMer("ACGT")[3:5]
+    end
 end

--- a/test/mers/access.jl
+++ b/test/mers/access.jl
@@ -107,18 +107,17 @@
     end
 
     @testset "Take slices of Mers" begin
-	import BioSequences
-	BioSequences.DNAMer("ACGT")[2:3] == BioSequences.DNAMer("CG")
-	BioSequences.BigDNAMer("ACGT")[2:3] == BioSequences.BigDNAMer("CG")
-	BioSequences.RNAMer("ACGU")[2:3] == BioSequences.RNAMer("CG")
-	BioSequences.BigRNAMer("ACGU")[2:3] == BioSequences.BigRNAMer("CG")
+	DNAMer("ACGT")[2:3] == DNAMer("CG")
+	BigDNAMer("ACGT")[2:3] == BigDNAMer("CG")
+	RNAMer("ACGU")[2:3] == RNAMer("CG")
+	BigRNAMer("ACGU")[2:3] == BigRNAMer("CG")
 
 	# ordinal range
-	BioSequences.DNAMer("ACGT")[2:1:3] == BioSequences.DNAMer("CG")
+	DNAMer("ACGT")[2:1:3] == DNAMer("CG")
 	# empty range
-	Test.@test_throws ArgumentError BioSequences.DNAMer("ACGT")[3:2]
+	@test_throws ArgumentError DNAMer("ACGT")[3:2]
 	# works if step is declared
-	BioSequences.DNAMer("ACGT")[3:-1:2] == BioSequences.DNAMer("GC")
-	Test.@test_throws BoundsError BioSequences.DNAMer("ACGT")[3:5]
+	DNAMer("ACGT")[3:-1:2] == DNAMer("GC")
+	@test_throws BoundsError DNAMer("ACGT")[3:5]
     end
 end

--- a/test/mers/access.jl
+++ b/test/mers/access.jl
@@ -107,14 +107,14 @@
     end
 
     @testset "Take slices of Mers" begin
-	DNAMer("ACGT")[2:3] == DNAMer("CG")
-	BigDNAMer("ACGT")[2:3] == BigDNAMer("CG")
-	RNAMer("ACGU")[2:3] == RNAMer("CG")
-	BigRNAMer("ACGU")[2:3] == BigRNAMer("CG")
+	@test DNAMer("ACGT")[2:3] == DNAMer("CG")
+	@test BigDNAMer("ACGT")[2:3] == BigDNAMer("CG")
+	@test RNAMer("ACGU")[2:3] == RNAMer("CG")
+	@test BigRNAMer("ACGU")[2:3] == BigRNAMer("CG")
 
-	DNAMer("ACGT")[2:1:3] == DNAMer("CG")
-	DNAMer("ACGT")[1:2:end] == DNAMer("CG")
-	DNAMer("ACGT")[3:-1:2] == DNAMer("GC")
+	@test DNAMer("ACGT")[2:1:3] == DNAMer("CG")
+	@test DNAMer("ACGT")[1:2:end] == DNAMer("AG")
+	@test DNAMer("ACGT")[3:-1:2] == DNAMer("GC")
 
 	@test_throws ArgumentError DNAMer("ACGT")[3:2]
 	@test_throws BoundsError DNAMer("ACGT")[3:5]


### PR DESCRIPTION
# A clear and descriptive title (No issue numbers please)

> _This template is rather extensive. Fill out all that you can, if are a new contributor or you're unsure about any section, leave it unchanged and a reviewer will help you_ :smile:. _This template is simply a tool to help everyone remember the BioJulia guidelines, if you feel anything in this template is not relevant, simply delete it._

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

- If you have implemented new features or behaviour
  - **Provide a description of the addition** in as many details as possible.

> Implement taking slices and ranges of AbstractMers

  - **Provide justification of the addition**.

> I find myself wanting to take subsequences of Mers often in practice, and rather than continuing to implement workarounds in my own code I'd like to put the functionality into the library itself

  - **Provide a runnable example of use of your addition**. This lets reviewers
    and others try out the feature before it is merged or makes it's way to release.

```julia
import BioSequences
kmer = BioSequences.DNAMer("TTTCAAAAAAAAAAAAAAAAAAAAAAAAA")
CPF1_PAMs = (BioSequences.DNAMer("TTTC"), BioSequences.DNAMer("TTTG"))
if kmer[1:4] in CPF1_PAMs
    spacer = kmer[5:end]
end
@show spacer
```

- If you have changed current behaviour...
  - **Describe the behaviour prior to you changes**

  - **Describe the behaviour after your changes** and justify why you have made the changes,
    Please describe any breakages you anticipate as a result of these changes.

  - **Does your change alter APIs or existing exposed methods/types?**
    If so, this may cause dependency issues and breakages, so the maintainer
    will need to consider this when versioning the next release.

  - If you are implementing changes that are intended to increase performance, you
    should provide the results of a simple performance benchmark exercise
    demonstrating the improvement. Especially if the changes make code less legible.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
> note this link and the documentation link below no longer link correctly
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
>🤞
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [ ] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
