### PR TITLE
Remove LongSequence copy-on-write

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -44,43 +44,11 @@ DNA_A
 !!! note
     Some types such as `Kmer` can be indexed using integers but not using ranges.
 
-For `LongSequence` types, indexing a sequence by range creates a subsequence
-of the original sequence.
-Unlike `Arrays` in the standard library, creating this subsequence is copy-free:
-the subsequence simply points to the original `LongSequence` data with its range.
-You may think that this is unsafe because modifying subsequences propagates to
-the original sequence, but this doesn't happen actually:
-
-```jldoctest
-julia> seq = dna"AAAA"    # create a sequence
-4nt DNA Sequence:
-AAAA
-
-julia> subseq = seq[1:2]  # create a subsequence from `seq`
-2nt DNA Sequence:
-AA
-
-julia> subseq[2] = DNA_T  # modify the second element of it
-DNA_T
-
-julia> subseq             # the subsequence is modified
-2nt DNA Sequence:
-AT
-
-julia> seq                # but the original sequence is not
-4nt DNA Sequence:
-AAAA
-
-```
-
-This is because modifying a sequence checks whether its underlying data are
-shared with other sequences under the hood.
-If and only if the data are shared, the subsequence creates a copy of itself.
-Any modifying operation does this check.
-This is called *copy-on-write* strategy and users don't need to care
-about it because it is transparent: If the user modifies a sequence with or
-subsequence, the job of managing and protecting the underlying data of sequences
-is handled for them.
+    
+For `LongSequence` types, indexing a sequence by range creates a copy of the
+original sequence, similar to `Array` in Julia's `Base` library. If you find yourself
+slowed down by the allocation of these subsequences, consider using a sequence view
+instead.
 
 ## Modifying sequences
 

--- a/src/biosequence/indexing.jl
+++ b/src/biosequence/indexing.jl
@@ -13,7 +13,7 @@ Indexing into BioSequences works as follows:
 A `Base.getindex` method is provided for `BioSequence`.
 It's job is to, do boundschecking. And to then call `inbounds_getindex`.
 
-It is the task of `inbounds_getindex` to extract from a sequence, the 
+It is the task of `inbounds_getindex` to extract from a sequence, the
 appropriate bits, and pass them to an appropriate `decode` method.
 =#
 
@@ -62,7 +62,7 @@ end
     inbounds_getindex(seq::BioSequence, i::Integer)
 
 An inbounds_getindex method defined by default for all BioSequences.
-    
+
 It is the job of this method to convert the integer index to a `BitIndex`, and
 call the method of inbounds_getindex, for the sequence and `BitIndex`
 combination.
@@ -92,6 +92,16 @@ end
 
 function checkdimension(seq::BioSequence, locs::AbstractVector{Bool})
     return checkdimension(length(seq), sum(locs))
+end
+
+@inline function unsafe_setindex!(s::BioSequence, v, i::Integer)
+    return unsafe_setindex!(s, v, bitindex(s, i))
+end
+
+@inline function unsafe_setindex!(s::BioSequence, v, i::BitIndex)
+    v_ = convert(eltype(s), v)
+    encoded = encode(Alphabet(s), v_)
+    return encoded_setindex!(s, encoded, i)
 end
 
 ###
@@ -141,6 +151,16 @@ end
 @inline function Base.getindex(seq::BioSequence, i::Integer)
     @boundscheck checkbounds(seq, i)
     return inbounds_getindex(seq, i)
+end
+
+@inline function Base.setindex!(s::BioSequence, v, i::Integer)
+    @boundscheck checkbounds(s, i)
+    return unsafe_setindex!(s, v, i)
+end
+
+function Base.setindex!(seq::BioSequence, x, locs::AbstractVector{<:Integer})
+    @boundscheck checkbounds(seq, locs)
+    return unsafe_setindex!(seq, x, locs)
 end
 
 @inline function Base.iterate(seq::BioSequence, i::Int = firstindex(seq))

--- a/src/bit-manipulation/bitindex.jl
+++ b/src/bit-manipulation/bitindex.jl
@@ -68,7 +68,10 @@ end
 # Create a bit mask that fills least significant `n` bits (`n` must be a
 # non-negative integer).
 "Create a bit mask covering the least significant `n` bits."
-bitmask(::Type{T}, n::Integer) where {T} = (one(T) << n) - one(T)
+function bitmask(::Type{T}, n::Integer) where {T}
+    topshift = 8 * sizeof(T) - 1
+    return ifelse(n > topshift, typemax(T), one(T) << (n & topshift) - one(T))
+end
 
 # Create a bit mask filling least significant N bits.
 # This is used in the extract_encoded_element function.

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -11,7 +11,7 @@ function LongSequence{A}(len::Integer) where {A<:Alphabet}
     if len < 0
         throw(ArgumentError("len must be non-negative"))
     end
-    return LongSequence{A}(Vector{UInt64}(undef, seq_data_len(A, len)), 1:convert(Int, len), false)
+    return LongSequence{A}(Vector{UInt64}(undef, seq_data_len(A, len)), convert(Int, len))
 end
 
 LongSequence(::Type{DNA}) = LongDNASeq()
@@ -20,7 +20,11 @@ LongSequence(::Type{AminoAcid}) = LongAminoAcidSeq()
 LongSequence(::Type{Char}) = LongCharSeq()
 
 function LongSequence()
-    return LongSequence{VoidAlphabet}(Vector{UInt64}(), 0:-1, false)
+    return LongSequence{VoidAlphabet}(Vector{UInt64}(), 0)
+end
+
+function LongSequence{A}(seq::LongSequence{A}, part::UnitRange) where A
+    return seq[part]
 end
 
 function LongSequence{A}(s::Union{String, SubString{String}}) where {A<:Alphabet}
@@ -50,17 +54,11 @@ function LongSequence{A}(
 end
 
 # create a subsequence
-function LongSequence(other::LongSequence{A}, part::UnitRange{<:Integer}) where {A}
+function LongSequence(other::LongSequence, part::UnitRange{<:Integer})
     checkbounds(other, part)
-    start = other.part.start + part.start - 1
-    stop = start + length(part) - 1
-    subseq = LongSequence{A}(other.data, start:stop, true)
-    other.shared = true
+    subseq = typeof(other)(length(part))
+    copyto!(subseq, 1, other, first(part), length(part))
     return subseq
-end
-
-function LongSequence{A}(other::LongSequence{A}, part::UnitRange) where {A}
-    return LongSequence(other, part)
 end
 
 # Create a 4 bit DNA/RNA sequences from a 2 bit DNA/RNA sequences, and vice-versa.
@@ -88,9 +86,7 @@ for (alpha, alphb) in [(DNAAlphabet{2}, RNAAlphabet{2}),
                        (RNAAlphabet{4}, DNAAlphabet{4})]
 
     @eval function (::Type{LongSequence{$alpha}})(seq::LongSequence{$alphb})
-        newseq = LongSequence{$alpha}(seq.data, seq.part, true)
-        seq.shared = true
-        return newseq
+        return  LongSequence{$alpha}(copy(seq.data), length(seq))
     end
 end
 
@@ -113,7 +109,7 @@ end
 function Base.repeat(chunk::LongSequence{A}, n::Integer) where {A}
     seq = LongSequence{A}(length(chunk) * n)
     offset = 1
-    for _ in 1:n
+    for i in 1:n
         copyto!(seq, offset, chunk, 1, length(chunk))
         offset += length(chunk)
     end

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -70,12 +70,17 @@ function (::Type{T})(seq::BioSequence) where {T<:LongSequence}
 end
 
 function LongSequence{A}(seq::LongSequence{A}) where {A <: Alphabet}
-    return LongSequence{A}(seq.data, seq.len)
+    return LongSequence{A}(copy(seq.data), seq.len)
 end
 
 function (::Type{T})(seq::LongSequence{<:NucleicAcidAlphabet{N}}) where
          {N, T<:LongSequence{<:NucleicAcidAlphabet{N}}}
     return T(copy(seq.data), seq.len)
+end
+
+# This exists to fix ambiguity errors with Julia 1.0
+function LongSequence{A}(seq::LongSequence{<:NucleicAcidAlphabet{N}}) where {N, A <: NucleicAcidAlphabet{N}}
+	return LongSequence{A}(copy(seq.data), seq.len)
 end
 
 # Concatenate multiple sequences

--- a/src/longsequences/conversion.jl
+++ b/src/longsequences/conversion.jl
@@ -20,23 +20,9 @@ end
 ### Conversion
 ###
 
-# Create a 4 bit DNA/RNA sequence from a 2 bit DNA/RNA sequence, and vice-versa.
-for (alpha, alphb) in [(DNAAlphabet{4}, DNAAlphabet{2}), # DNA to DNA
-                       (DNAAlphabet{2}, DNAAlphabet{4}),
-                       (RNAAlphabet{4}, RNAAlphabet{2}), # RNA to RNA
-                       (RNAAlphabet{2}, RNAAlphabet{4}),
-                       (DNAAlphabet{2}, RNAAlphabet{4}), # DNA to RNA
-                       (DNAAlphabet{4}, RNAAlphabet{2}),
-                       (DNAAlphabet{2}, RNAAlphabet{2}),
-                       (DNAAlphabet{4}, RNAAlphabet{4}),
-                       (RNAAlphabet{4}, DNAAlphabet{2}), # RNA to DNA
-                       (RNAAlphabet{2}, DNAAlphabet{4}),
-                       (RNAAlphabet{2}, DNAAlphabet{2}),
-                       (RNAAlphabet{4}, DNAAlphabet{4})]
-
-    @eval function Base.convert(::Type{LongSequence{$alpha}}, seq::LongSequence{$alphb})
-        return LongSequence{$alpha}(seq)
-    end
+function Base.convert(::Type{T}, seq::LongSequence{<:NucleicAcidAlphabet}) where
+         {T<:LongSequence{<:NucleicAcidAlphabet}}
+    return T(seq)
 end
 
 # Convert from a LongSequence to to a DNA or RNA vector

--- a/src/longsequences/conversion.jl
+++ b/src/longsequences/conversion.jl
@@ -33,7 +33,7 @@ for (alpha, alphb) in [(DNAAlphabet{4}, DNAAlphabet{2}), # DNA to DNA
                        (RNAAlphabet{2}, DNAAlphabet{4}),
                        (RNAAlphabet{2}, DNAAlphabet{2}),
                        (RNAAlphabet{4}, DNAAlphabet{4})]
-    
+
     @eval function Base.convert(::Type{LongSequence{$alpha}}, seq::LongSequence{$alphb})
         return LongSequence{$alpha}(seq)
     end
@@ -45,4 +45,3 @@ function Base.convert(::Type{LongSequence{A}}, seq::Vector) where A<:Alphabet
 end
 
 Base.parse(::Type{LongSequence{A}}, seq::AbstractString) where A = LongSequence{A}(seq)
-

--- a/src/longsequences/copying.jl
+++ b/src/longsequences/copying.jl
@@ -36,17 +36,9 @@ function Base.copy!(dst::LongSequence{<:NucleicAcidAlphabet{N}},
 end
 
 function _copy!(dst::LongSequence, src::LongSequence)
-    orphan!(dst)
-    # Most efficient
-    if !src.shared
-        resize!(dst.data, length(src.data))
-        copyto!(dst.data, src.data)
-        dst.part = src.part
-    # Less efficient
-    else
-        resize!(dst, length(src))
-        copyto!(dst, src)
-    end
+    resize!(dst.data, length(src.data))
+    copyto!(dst.data, src.data)
+    dst.len = src.len
     return dst
 end
 
@@ -101,9 +93,6 @@ function _copyto!(dst::LongSequence{A}, doff::Integer,
     @boundscheck checkbounds(dst, doff:doff+N-1)
     @boundscheck checkbounds(src, soff:soff+N-1)
 
-    if dst.shared
-        orphan!(dst)
-    end
     # This prevents a sequence from destructively overwriting its own data
     if (dst === src) & (doff > soff)
         return _copyto!(dst, doff, copy(src[soff:soff+N-1]), 1, N)
@@ -137,15 +126,7 @@ function _copyto!(dst::LongSequence{A}, doff::Integer,
     return dst
 end
 
-function Base.copy(seq::LongSequence)
-    if seq.shared
-        newseq = typeof(seq)(seq.data, seq.part, true)
-        orphan!(newseq, length(seq), true)
-    else
-        newseq = typeof(seq)(copy(seq.data), seq.part, false)
-    end
-    return newseq
-end
+Base.copy(seq::LongSequence) = typeof(seq)(copy(seq.data), seq.len)
 
 #########
 const SeqLike = Union{AbstractVector, AbstractString}
@@ -315,23 +296,12 @@ function Base.copyto!(dst::LongSequence{A}, doff::Integer,
     checkbounds(dst, doff:doff+len-1)
     length(src) < soff + len - 1 && throw_enc_indexerr(len, length(src), soff)
 
-    orphan!(dst)
-
-    next = bitindex(dst, doff)
-    stop = bitindex(dst, doff + len)
-
+    n = 0
     i = soff
-    while next < stop
-        x = UInt64(0)
-        j = index(next)
-        while index(next) == j && next < stop
-            char = src[i]
-            i = nextind(src, i)
-            x |= enc64(dst, convert(Char, char)) << offset(next)
-            #TODO: Resolve this use of bits_per_symbol...
-            next += bits_per_symbol(A())
-        end
-        dst.data[j] = x
+    @inbounds while n < len
+        n += 1
+        dst[doff + n - 1] = src[i]
+        i = nextind(src, i)
     end
     return dst
 end
@@ -341,7 +311,6 @@ function Base.copyto!(dst::LongSequence{A}, doff::Integer, src::AbstractVector{U
                       soff::Integer, N::Integer, ::AsciiAlphabet) where {A<:Alphabet}
     checkbounds(dst, doff:doff+N-1)
     length(src) < soff + N - 1 && throw_enc_indexerr(N, length(src), soff)
-    orphan!(dst)
     bitind = bitindex(dst, doff)
     remaining = N
 

--- a/src/longsequences/indexing.jl
+++ b/src/longsequences/indexing.jl
@@ -98,9 +98,10 @@ function unsafe_setindex!(seq::LongSequence{A},
 end
 
 @inline function encoded_setindex!(seq::LongSequence{A},
-				   bin::UInt64, i::Integer) where {A <: Alphabet}
+				   bin::Unsigned, i::Integer) where {A <: Alphabet}
     j, r = bitindex(seq, i)
+	bin_ = bin % encoded_data_eltype(seq)
     data = encoded_data(seq)
-    @inbounds data[j] = (bin << r) | (data[j] & ~(bindata_mask(seq) << r))
+    @inbounds data[j] = (bin_ << r) | (data[j] & ~(bindata_mask(seq) << r))
     return seq
 end

--- a/src/longsequences/indexing.jl
+++ b/src/longsequences/indexing.jl
@@ -6,35 +6,10 @@
 
 # assumes `i` is positive and `bitsof(A)` is a power of 2
 
-@inline function bitindex(seq::LongSequence, i::Integer)
-    return bitindex(BitsPerSymbol(seq), encoded_data_eltype(seq), i + first(seq.part) - 1)
-end
-
-@inline function Base.getindex(seq::LongSequence, part::UnitRange)
-    return LongSequence(seq, part)
-end
-@inline function Base.view(seq::LongSequence, part::UnitRange)
-    return getindex(seq, part)
-end
-
-# Set a single sequence position to a single symbol value.
-function Base.setindex!(seq::LongSequence, x, i::Integer)
-    @boundscheck checkbounds(seq, i)
-    orphan!(seq)
-    return unsafe_setindex!(seq, x, i)
-end
-
-# Set multiple sequence positions to a single symbol value.
-function Base.setindex!(seq::LongSequence{A}, x, locs::AbstractVector{<:Integer}) where {A}
-    @boundscheck checkbounds(seq, locs)
-    orphan!(seq)
-    return unsafe_setindex!(seq, x, locs)
-end
-
-function Base.setindex!(seq::LongSequence{A}, x, locs::AbstractVector{Bool}) where {A}
-    @boundscheck checkbounds(seq, locs)
-    orphan!(seq)
-    return unsafe_setindex!(seq, x, locs)
+function Base.getindex(seq::LongSequence, part::UnitRange{<:Integer})
+	@boundscheck checkbounds(seq, part)
+	newseq = typeof(seq)(length(part))
+	return copyto!(newseq, 1, seq, first(part), length(part))
 end
 
 function Base.setindex!(seq::LongSequence{A},
@@ -42,7 +17,6 @@ function Base.setindex!(seq::LongSequence{A},
                         locs::AbstractVector{<:Integer}) where {A}
     @boundscheck checkbounds(seq, locs)
     checkdimension(other, locs)
-    orphan!(seq)
     return unsafe_setindex!(seq, other, locs)
 end
 
@@ -51,7 +25,6 @@ function Base.setindex!(seq::LongSequence{A},
                         locs::AbstractVector{Bool}) where {A}
     @boundscheck checkbounds(seq, locs)
     checkdimension(other, locs)
-    orphan!(seq)
     return unsafe_setindex!(seq, other, locs)
 end
 
@@ -72,22 +45,25 @@ function Base.setindex!(seq::LongSequence{A}, x, ::Colon) where {A}
     return setindex!(seq, x, 1:lastindex(seq))
 end
 
-# These are "unsafe" because of no bounds check and no orphan! call
-@inline function unsafe_setindex!(seq::LongSequence{A}, x, i::Integer) where {A}
-    bin = enc64(seq, x)
-    return encoded_setindex!(seq, bin, i)
+@inline function encoded_setindex!(s::LongSequence, v::Unsigned, i::BitIndex)
+    vi, off = i
+    data = encoded_data(s)
+    bits = @inbounds data[vi]
+	v_ = v % encoded_data_eltype(s)
+    @inbounds data[vi] = (v_ << off) | (bits & ~(bindata_mask(s) << off))
+    return s
 end
 
-@inline function unsafe_setindex!(seq::LongSequence{A}, x, locs::AbstractVector{<:Integer}) where {A}
-    bin = enc64(seq, x)
+@inline function unsafe_setindex!(seq::LongSequence, x, locs::AbstractVector{<:Integer})
+	bin = encode(Alphabet(seq), convert(eltype(seq), x))
     for i in locs
-        encoded_setindex!(seq, bin, i)
+        encoded_setindex!(seq, bin, bitindex(seq, i))
     end
     return seq
 end
 
-function unsafe_setindex!(seq::LongSequence{A}, x, locs::AbstractVector{Bool}) where {A}
-    bin = enc64(seq, x)
+function unsafe_setindex!(seq::LongSequence, x, locs::AbstractVector{Bool})
+    bin = encode(Alphabet(seq), convert(eltype(seq), x))
     i = j = 0
     while true
         i = findnext(locs, i + 1)
@@ -99,7 +75,8 @@ function unsafe_setindex!(seq::LongSequence{A}, x, locs::AbstractVector{Bool}) w
     return seq
 end
 
-function unsafe_setindex!(seq::LongSequence{A}, other::LongSequence{A}, locs::AbstractVector{<:Integer}) where{A}
+function unsafe_setindex!(seq::LongSequence{A}, other::LongSequence{A},
+	                      locs::AbstractVector{<:Integer}) where {A <: Alphabet}
     for (i, x) in zip(locs, other)
         unsafe_setindex!(seq, x, i)
     end
@@ -108,7 +85,7 @@ end
 
 function unsafe_setindex!(seq::LongSequence{A},
                           other::LongSequence{A},
-                          locs::AbstractVector{Bool}) where {A}
+                          locs::AbstractVector{Bool}) where {A <: Alphabet}
     i = j = 0
     while true
         i = findnext(locs, i + 1)
@@ -120,27 +97,10 @@ function unsafe_setindex!(seq::LongSequence{A},
     return seq
 end
 
-function enc64(::LongSequence{A}, x) where {A}
-    #TODO: Resolve these two use cases of A().
-    return UInt64(encode(A(), convert(eltype(A()), x)))
-end
-
 @inline function encoded_setindex!(seq::LongSequence{A},
-				   bin::UInt64, i::Integer) where {A}
+				   bin::UInt64, i::Integer) where {A <: Alphabet}
     j, r = bitindex(seq, i)
     data = encoded_data(seq)
     @inbounds data[j] = (bin << r) | (data[j] & ~(bindata_mask(seq) << r))
     return seq
 end
-
-#=
-function Base.iterate(seq::LongSequence{A}, off::Int=first(seq.part)-1) where {A <: Alphabet}
-    off == last(seq.part) && return nothing
-    bps = bits_per_symbol(A())
-    @inbounds chunk = seq.data[(off >>> index_shift(BitsPerSymbol(A()))) + 1]
-    shift = (unsigned(off) * bps) & 63
-    encoding = (chunk >>> shift) & bitmask(A())
-    return decode(A(), encoding), off + 1
-end
-
-=#

--- a/src/longsequences/randseq.jl
+++ b/src/longsequences/randseq.jl
@@ -173,7 +173,7 @@ randseq(A::Alphabet, len::Integer) = randseq(DEFAULT_RNG, A, len)
 
 function randseq_allbits(rng::AbstractRNG, A::Alphabet, len::Integer)
     vector = rand(rng, UInt64, seq_data_len(typeof(A), len))
-    return LongSequence{typeof(A)}(vector, 1:len, false)
+    return LongSequence{typeof(A)}(vector, len)
 end
 
 """

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -138,10 +138,8 @@ end
 Make a complement sequence of `seq` in place.
 """
 function complement!(seq::LongSequence{A}) where {A<:NucleicAcidAlphabet}
-    next = index(firstbitindex(seq))
-    stop = index(lastbitindex(seq))
     seqdata = seq.data
-    @inbounds for i in index(firstbitindex(seq)):index(lastbitindex(seq))
+    @inbounds for i in eachindex(seqdata)
         seqdata[i] = complement_bitpar(seqdata[i], Alphabet(seq))
     end
     return seq

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -12,11 +12,6 @@
         test_copy(AminoAcidAlphabet, random_aa(len))
         test_copy(CharAlphabet, random_aa(len))
     end
-
-    # Test copying shared seq
-    seq = LongSequence{DNAAlphabet{2}}(random_dna(50, [0.25, 0.25, 0.25, 0.25]))
-    seq2 = seq[5:44]
-    @test String(seq)[5:44] == String(seq2)
 end # testset
 
 @testset "Copy! sequence" begin

--- a/test/longsequences/conversion.jl
+++ b/test/longsequences/conversion.jl
@@ -92,7 +92,7 @@ end
 @testset "Encode_copy!" begin
     # Note: Other packages use this function, so we need to test it
     # Even though this is NOT exported or part of the API in a normal sense
-    function test_copyto!(dst::LongSequence{}, doff, src, soff, N)
+    function test_copyto!(dst::LongSequence, doff, src, soff, N)
         BioSequences.copyto!(dst, doff, src, soff, N)
         @test String(dst[doff:doff+N-1]) == String(src[soff:soff+N-1])
     end

--- a/test/longsequences/mutability.jl
+++ b/test/longsequences/mutability.jl
@@ -158,15 +158,4 @@
         seq = dna"ACGT"
         @test copyto!(seq, 3, seq, 1, 2) == dna"ACAC"
     end
-
-    @testset "orphan!" begin
-        seq = repeat(dna"ACGT", 8)
-        subseq = seq[16:17]
-        BioSequences.orphan!(subseq)
-        @test subseq == dna"TA"
-
-        subseq = seq[16:20]
-        BioSequences.orphan!(subseq, 3)
-        @test subseq == dna"TAC"
-    end
 end


### PR DESCRIPTION
As discussed in #118 , this PR removes the entire copy-on-write mechanism for `LongSequence`. As a result, the code is now a little cleaner and easier to work with.

### Notable changes:
* `LongSequence` now has a new layout:
Before:
```
mutable struct LongSequence{A <: Alphabet}
    data::Vector{UInt64}
    part::UnitRange{Int}
    shared::Bool
end
```
After:
```
mutable struct LongSequence{A <: Alphabet}
    data::Vector{UInt64}
    len::Int
end
```
* Slicing a `LongSequence` now copies the underlying data - not all of it, just the relevant part.
* A few function has been made more efficient due to lack of `orphan!` calls. Gains are very modest tbh.
* Refactored the `LongSequence` hashing code to use functions instead of macros (more generic, to be used for SeqView eventually). Behaviour and performance is identical.

### What needs to be done
I would like to take another pass over the codebase and remove any unused functions and simplify what can be simplified. I'm a little disappointed that not more lines were deleted.

Also now might be a good time to do some spring cleaning of the tests. These can presumably be simplified a lot since we no longer need to test orphan! or subsequences. Also, the code coverage could be better.