### PR TITLE
Make same-type conversion noop

### DIFF
--- a/src/longsequences/conversion.jl
+++ b/src/longsequences/conversion.jl
@@ -19,6 +19,8 @@ end
 ###
 ### Conversion
 ###
+Base.convert(::Type{T}, seq::T) where {T <: LongSequence} = seq
+Base.convert(::Type{T}, seq::T) where {T <: LongSequence{<:NucleicAcidAlphabet}} = seq
 
 function Base.convert(::Type{T}, seq::LongSequence{<:NucleicAcidAlphabet}) where
          {T<:LongSequence{<:NucleicAcidAlphabet}}

--- a/test/longsequences/conversion.jl
+++ b/test/longsequences/conversion.jl
@@ -121,6 +121,17 @@ end
     end
 end
 
+@testset "Convert to same type" begin
+	function test_same_conversion(seq)
+		@test convert(typeof(seq), seq) === seq
+	end
+
+	test_same_conversion(random_dna(20))
+	test_same_conversion(random_rna(20))
+	test_same_conversion(random_aa(20))
+	test_same_conversion(LongSequence{CharAlphabet}("∈α"))
+end
+
 @testset "Conversion between 2-bit and 4-bit encodings" begin
     function test_conversion(A1, A2, seq)
         @test convert(LongSequence{A1}, LongSequence{A2}(seq)) == LongSequence{A1}(seq)


### PR DESCRIPTION
On master, the following method is defined:
```
function Base.convert(::Type{T}, seq::LongSequence{<:NucleicAcidAlphabet}) where
         {T<:LongSequence{<:NucleicAcidAlphabet}}
    return T(seq)
end
```
Seems reasonable enough, right? We want to be able to convert between nucleotide sequences.
Except that it causes this:
```
julia> seq = dna"TAG"
3nt DNA Sequence:
TAG

julia> convert(typeof(seq), seq) === seq
false
```
What's the big deal? If we call convert, we probably want a separate copy anyway.
Well, the problem is that Julia sometimes implicitly calls convert:
```
julia> struct Foo{T}
           x::T
       end

julia> seq = dna"TAG"
3nt DNA Sequence:
TAG

julia> foo = Foo{typeof(seq)}(seq)
Foo{LongSequence{DNAAlphabet{4}}}(TAG)

julia> foo.x === seq
false
```
As far as I can tell, that makes it impossible to wrap a `LongSequence`! Clearly, that's completely unworkable.
This PR simply defines `Base.convert(::Type{T}, seq::T) where {T <: LongSequence} = seq`.
Note that this may be considered breaking behaviour, but I think this needs to happen.