### PR TITLE
Fix `ReferenceSequence` slicing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Ability to take a slice of an AbstractMer over a range
 
+### Changed
+- Fix `ReferenceSequence` slicing bug where the wrapped data is sliced instead.
+
 ## [2.0.1]
 ### Changed
 - Fixed syntax errors where functions were marked with `@inbounds` instead of

--- a/src/refseq/refseq.jl
+++ b/src/refseq/refseq.jl
@@ -156,8 +156,9 @@ end
 end
 
 function Base.getindex(seq::ReferenceSequence, part::UnitRange{<:Integer})
-    checkbounds(seq, part)
-    return ReferenceSequence(seq, part)
+    sub_part = seq.part[part]
+    checkbounds(seq, sub_part)
+    return ReferenceSequence(seq, sub_part)
 end
 
 function find_next_ambiguous(seq::ReferenceSequence, i::Integer)

--- a/test/refseq/basics.jl
+++ b/test/refseq/basics.jl
@@ -16,12 +16,16 @@
     @test seq[3] === DNA_G
     @test seq[4] === DNA_T
     @test seq[5] === DNA_N
+    @test seq[2:5][2] === DNA_G
     @test seq[2:3] == dna"CG"
     @test seq[3:5] == dna"GTN"
     @test seq[5:4] == dna""
+    @test seq[2:5][1:3] == dna"CGT"
     @test_throws BoundsError seq[0]
     @test_throws BoundsError seq[6]
+    @test_throws BoundsError seq[2:5][5]
     @test_throws BoundsError seq[0:2]
     @test_throws BoundsError seq[5:6]
+    @test_throws BoundsError seq[2:5][4:5]
     @test collect(seq) == [DNA_A, DNA_C, DNA_G, DNA_T, DNA_N]
 end


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Previously slicing into `ReferenceSequence` will slice the wrapped data instead (#114). This PR provides a fix, and the following code now reflects the expected behavior:

```
julia> using BioSequences
[ Info: Precompiling BioSequences [7e6ae17a-c86d-528c-b3b9-7f778a29fe59]
[ Info: Compiling bit-parallel GC counter for LongSequence{<:NucleicAcidAlphabet}
[ Info: Compiling bit-parallel mismatch counter for LongSequence{<:NucleicAcidAlphabet}
[ Info: Compiling bit-parallel match counter for LongSequence{<:NucleicAcidAlphabet}
[ Info: Compiling bit-parallel ambiguity counter...
[ Info: 	For a single LongSequence{<:NucleicAcidAlphabet}
[ Info: 	For a pair of LongSequence{<:NucleicAcidAlphabet}s
[ Info: Compiling bit-parallel certainty counter for LongSequence{<:NucleicAcidAlphabet}
[ Info: Compiling bit-parallel gap counter for LongSequence{<:NucleicAcidAlphabet}

julia> rseq = ReferenceSequence(dna"NNAAANAAN")
9nt Reference Sequence:
NNAAANAAN

julia> sub_rseq = rseq[3:8]
6nt Reference Sequence:
AAANAA

julia> sub_sub_rseq = sub_rseq[1:4] # previously returns NNAA
4nt Reference Sequence:
AAAN
```

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
