### PR TITLE
Allow hamming circle around N

### DIFF
--- a/src/demultiplexer.jl
+++ b/src/demultiplexer.jl
@@ -237,7 +237,7 @@ function hamming_circle(seq, m)
         for rs in Iterators.product(fill(1:4, m)...)
             seq′ = copy(seq)
             for (p, r) in zip(ps, rs)
-                if findfirst(isequal(seq[p]), ACGT) ≤ r
+                if findfirst(isequal(seq[p]), ACGTN) ≤ r
                     r += 1
                 end
                 seq′[p] = ACGTN[r]

--- a/test/demultiplexer.jl
+++ b/test/demultiplexer.jl
@@ -118,4 +118,13 @@
         @test n_ok / 10_000 > 0.99
         @test n_ok < n_ok_with_fallback
     end
+
+    @testset "Hamming circle" begin
+        @test sort(BioSequences.hamming_circle(dna"A",1)) == [dna"C",dna"G",dna"T",dna"N"]
+        @test sort(BioSequences.hamming_circle(dna"N",1)) == [dna"A",dna"C",dna"G",dna"T"]
+    end
+    @testset "Levenshtein circle" begin
+        @test sort(BioSequences.levenshtein_circle(dna"A",1)) == [dna"", dna"C", dna"CA", dna"G", dna"GA", dna"T", dna"TA", dna"N", dna"NA"]
+        @test sort(BioSequences.levenshtein_circle(dna"N",1)) == [dna"", dna"A", dna"AN", dna"C", dna"CN", dna"G", dna"GN", dna"T", dna"TN"]
+    end
 end

--- a/test/demultiplexer.jl
+++ b/test/demultiplexer.jl
@@ -127,4 +127,13 @@
         @test sort(BioSequences.levenshtein_circle(dna"A",1)) == [dna"", dna"C", dna"CA", dna"G", dna"GA", dna"T", dna"TA", dna"N", dna"NA"]
         @test sort(BioSequences.levenshtein_circle(dna"N",1)) == [dna"", dna"A", dna"AN", dna"C", dna"CN", dna"G", dna"GN", dna"T", dna"TN"]
     end
+    @testset "Levenshtein distance 2" begin
+        barcodes = [dna"ATGGC", dna"GGAAG"]
+        dplxr2 = Demultiplexer(barcodes, n_max_errors=2, distance=:levenshtein)
+
+        @test demultiplex(dplxr2, dna"ATGGC") === (1, 0)
+        @test demultiplex(dplxr2, dna"ATGG")  === (1, 1)
+        @test demultiplex(dplxr2, dna"ATG")   === (1, 2)
+        @test demultiplex(dplxr2, dna"TACG")  === (0, -1)
+    end
 end


### PR DESCRIPTION
# Allow hamming circle around N

This fixes #124 : Demultiplexer fails for Levenshtein distance > 1

The problem was that the `levenshtein_circle` function generates sequences containing N, but the `hamming_circle` function was not able to create a circle around those.

With this change, the circle around N is created as [A,C,G,T]

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [X] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

### Before the change:

```
julia> BioSequences.hamming_circle(dna"N",1)
ERROR: MethodError: no method matching isless(::Nothing, ::Int64)
Closest candidates are:
  isless(::Missing, ::Any) at missing.jl:87
  isless(::AbstractFloat, ::Real) at operators.jl:167
  isless(::Real, ::Real) at operators.jl:355
  ...
Stacktrace:
 [1] <(::Nothing, ::Int64) at /opt/Julia/julia-1.5.2/share/julia/base/operators.jl:277
 [2] <=(::Nothing, ::Int64) at /opt/Julia/julia-1.5.2/share/julia/base/operators.jl:326
 [3] hamming_circle(::LongSequence{DNAAlphabet{4}}, ::Int64) at /home/tp/Julia/Pull/2020-10-31_demultiplex/BioSequences.jl/src/demultiplexer.jl:240
 [4] top-level scope at REPL[41]:1

```
### With change

```
julia> BioSequences.hamming_circle(dna"N",1)
4-element Array{LongSequence{DNAAlphabet{4}},1}:
 A
 C
 G
 T
```

## :ballot_box_with_check: Checklist

- [X] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [X] :ok: There are unit tests that cover the code changes I have made.
- [X] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [X] :ok: All changes should be compatible with the latest stable version of Julia.
- [] :thought_balloon: I have commented liberally for any complex pieces of internal code.
