### PR TITLE
Fix reversing seq with unused data

### DIFF
--- a/src/longsequences/longsequence.jl
+++ b/src/longsequences/longsequence.jl
@@ -62,6 +62,7 @@ Base.length(seq::LongSequence) = seq.len
 bindata(seq::LongSequence) = seq.data
 Base.eltype(::Type{LongSequence{A}}) where {A} = eltype(A)
 
+@inline seq_data_len(s::LongSequence{A}) where A = seq_data_len(A, length(s))
 @inline function seq_data_len(::Type{A}, len::Integer) where A <: Alphabet
     return cld(len, div(64, bits_per_symbol(A())))
 end

--- a/test/longsequences/transformations.jl
+++ b/test/longsequences/transformations.jl
@@ -85,6 +85,10 @@
         @test String(seq) == seq_string
         @test String(seq2) == reverse(dna_complement(seq_string[100:200]))
 
+        # Test RC'ing works even with extra data in data buffer
+        seq = ungap!(dna"ACTG-----------CCAG")
+        @test String(reverse_complement(seq)) == reverse(dna_complement(String(seq)))
+
 	slice = randdnaseq(10)[2:9]
 	@test reverse_complement(reverse_complement(slice)) == slice
     end


### PR DESCRIPTION
MWE to reproduce bug:
```
julia> using BioSequences

julia> seq = ungap!(dna"TAGC------------ACC")
7nt DNA Sequence:
TAGCACC

julia> reverse_complement(seq)
7nt DNA Sequence:
----GGT
```
What happened was that the reversing functions assumed that `length(seq.data) == seq_data_len(typeof(Alphabet(seq)), length(seq)`, which is not a valid guarantee (i.e: `LongSequences` are allowed to have noncoding elements at the end of their `data` vector).