### PR TITLE
Refactor translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Ability to take a slice of an AbstractMer over a range
+- Added method `translate!(::LongAminoAcidSeq, ::LongNucleotideSeq; kwargs...)`
+- Added method `translate(::Union{DNACodon, RNACodon}, ::GeneticCode)`
 
 ### Changed
 - Fix `ReferenceSequence` slicing bug where the wrapped data is sliced instead.

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -213,7 +213,8 @@ export
     Composition,
     composition,
     NucleicAcidCounts,
-    
+
+    translate!,
     translate,
     ncbi_trans_table,
     

--- a/test/translation.jl
+++ b/test/translation.jl
@@ -36,9 +36,12 @@
         return string_translate(seq) == String(translate(LongRNASeq(seq)))
     end
 
+    aas = aa""
     global reps = 10
     for len in [1, 10, 32, 1000, 10000, 100000]
         @test all(Bool[check_translate(random_translatable_rna(len)) for _ in 1:reps])
+        seq = LongDNASeq(LongRNASeq(random_translatable_rna(len)))
+        @test translate!(aas, seq) == translate(seq)
     end
 
     # ambiguous codons
@@ -61,4 +64,11 @@
 
     # issue #133
     @test translate(rna"GAN") == aa"X"
+
+    # Translate kmers
+    for T in (RNACodon, DNACodon)
+        @test translate(T(mer"TAG")) == AA_Term
+        @test translate(T(mer"AAC")) == AA_N
+        @test translate(T(mer"CCT")) == AA_P
+    end
 end


### PR DESCRIPTION
# Refactor translation code

A quick optimization pass over the translation code.

## Types of changes

This PR implements the following changes:

* [X] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

__Changes__
* Optimization of existing code (see benchmarks below)
* Added method `translate!(::LongAminoAcidSeq, ::LongNucleotideSeq); kwargs...`, which avoids allocations. Same kwargs as existing `translate`. Useful for translating small sequences quickly.
* Added method `translate(::Union{DNACodon, RNACodon}, ::GeneticCode)` which efficiently translates a codon. The code defaults to the standard genetic code. This method does no checking, i.e. if you create an invalid genetic code (including nonsense amino acids), this will return those amino acids.

None of the above changes are breaking.

__Benchmarks__
Translating 100 sequences of length `3 * rand(100:3000)`. Mean times:

```
Before:
NucleicAcidAlphabet{4}: 1924 µs
NucleicAcidAlphabet{2}: 2225 µs

After:
NucleicAcidAlphabet{4}: 767 µs  (2.5 x)
NucleicAcidAlphabet{2}: 714 µs  (3.1 x)

After (in-place translation):
NucleicAcidAlphabet{4}: 669 µs (2.9 x)
NucleicAcidAlphabet{2}: 575 µs (3.9 x)
```

## :ballot_box_with_check: Checklist

- [X] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [X] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [X] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [X] :ok: There are unit tests that cover the code changes I have made.
- [X] :ok: The unit tests cover my code changes AND they pass.
- [X] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [X] :ok: All changes should be compatible with the latest stable version of Julia.
- [X] :thought_balloon: I have commented liberally for any complex pieces of internal code.
