### PR TITLE
Move some indexing logic from LongSequence to BioSequence

### DIFF
--- a/src/biosequence/indexing.jl
+++ b/src/biosequence/indexing.jl
@@ -163,6 +163,36 @@ function Base.setindex!(seq::BioSequence, x, locs::AbstractVector{<:Integer})
     return unsafe_setindex!(seq, x, locs)
 end
 
+function Base.setindex!(seq::BioSequence, x::BioSequence, locs::AbstractVector{<:Integer})
+    @boundscheck checkbounds(seq, locs)
+    checkdimension(x, locs)
+    @inbounds for i in eachindex(locs)
+        unsafe_setindex!(seq, x[i], locs[i])
+    end
+    seq
+end
+
+function Base.setindex!(seq::BioSequence, x::BioSequence, locs::AbstractVector{Bool})
+    @boundscheck checkbounds(seq, locs)
+    checkdimension(x, locs)
+    j = 0
+    @inbounds for i in eachindex(locs)
+        if locs[i]
+            j += 1
+            unsafe_setindex!(seq, x[j], i)
+        end
+    end
+    seq
+end
+
+function Base.setindex!(seq::BioSequence, other::BioSequence, ::Colon)
+    return setindex!(seq, other, 1:lastindex(seq))
+end
+
+function Base.setindex!(seq::BioSequence, x, ::Colon)
+    return setindex!(seq, x, 1:lastindex(seq))
+end
+
 @inline function Base.iterate(seq::BioSequence, i::Int = firstindex(seq))
     if i > lastindex(seq)
         return nothing

--- a/src/longsequences/indexing.jl
+++ b/src/longsequences/indexing.jl
@@ -18,35 +18,10 @@ end
 
 function Base.setindex!(seq::SeqOrView{A},
                         other::SeqOrView{A},
-                        locs::AbstractVector{<:Integer}) where {A}
-    @boundscheck checkbounds(seq, locs)
-    checkdimension(other, locs)
-    return unsafe_setindex!(seq, other, locs)
-end
-
-function Base.setindex!(seq::SeqOrView{A},
-                        other::SeqOrView{A},
-                        locs::AbstractVector{Bool}) where {A}
-    @boundscheck checkbounds(seq, locs)
-    checkdimension(other, locs)
-    return unsafe_setindex!(seq, other, locs)
-end
-
-function Base.setindex!(seq::SeqOrView{A},
-                        other::SeqOrView{A},
                         locs::UnitRange{<:Integer}) where {A}
     @boundscheck checkbounds(seq, locs)
     checkdimension(other, locs)
     return copyto!(seq, locs.start, other, 1, length(locs))
-end
-
-function Base.setindex!(seq::SeqOrView{A},
-			            other::SeqOrView{A}, ::Colon) where {A}
-    return setindex!(seq, other, 1:lastindex(seq))
-end
-
-function Base.setindex!(seq::SeqOrView{A}, x, ::Colon) where {A}
-    return setindex!(seq, x, 1:lastindex(seq))
 end
 
 @inline function encoded_setindex!(seq::SeqOrView{A},

--- a/src/longsequences/seqview.jl
+++ b/src/longsequences/seqview.jl
@@ -27,7 +27,7 @@ function LongSubSeq(seq::SeqOrView{A}) where {A <: Alphabet}
 	return LongSubSeq{A}(seq)
 end
 
-function LongSubSeq{A}(seq::LongSequence{A}, part::UnitRange{Int}) where {A <: Alphabet}
+function LongSubSeq{A}(seq::LongSequence{A}, part::UnitRange{<:Integer}) where {A <: Alphabet}
     @boundscheck checkbounds(seq, part)
     return LongSubSeq{A}(seq.data, part)
 end


### PR DESCRIPTION
This simply moves some of the general indexing logic from LongSequence to BioSequence, to make it more general. For example, you can now do
```julia
julia> a = dna"TAGC";

julia> a[2:4] = mer"ATG";

julia> a
4nt DNA Sequence:
TATG
```