### PR TITLE
Add join and join! for BioSequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ability to take a slice of an AbstractMer over a range
 - Added method `translate!(::LongAminoAcidSeq, ::LongNucleotideSeq; kwargs...)`
 - Added method `translate(::Union{DNACodon, RNACodon}, ::GeneticCode)`
+- Added method `join(::Type{T<:BioSeuence}, it)` to join an iterable of biosequences
+to a new instance of T.
+- Added method `join!(s::BioSequence, it)`, an in-place version of `join`
 
 ### Deprecated
 - `minhash` functionality is now deprecated and will be removed in v3.

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -106,6 +106,8 @@ export
     ###
     ### BioSequences
     ###
+
+    join!,
     
     # Type & aliases
     BioSequence,

--- a/src/biosequence/biosequence.jl
+++ b/src/biosequence/biosequence.jl
@@ -93,6 +93,7 @@ function _join!(result::BioSequence, seqs, ::Val{resize}) where resize
         result[offset+1:offset+seqlen] = seq
         offset += seqlen
     end
+    resize && resize!(result, offset)
     result
 end
 

--- a/src/biosequence/indexing.jl
+++ b/src/biosequence/indexing.jl
@@ -163,6 +163,36 @@ function Base.setindex!(seq::BioSequence, x, locs::AbstractVector{<:Integer})
     return unsafe_setindex!(seq, x, locs)
 end
 
+function Base.setindex!(seq::BioSequence, x::BioSequence, locs::AbstractVector{<:Integer})
+    @boundscheck checkbounds(seq, locs)
+    checkdimension(x, locs)
+    @inbounds for i in eachindex(locs)
+        unsafe_setindex!(seq, x[i], locs[i])
+    end
+    seq
+end
+
+function Base.setindex!(seq::BioSequence, x::BioSequence, locs::AbstractVector{Bool})
+    @boundscheck checkbounds(seq, locs)
+    checkdimension(x, locs)
+    j = 0
+    @inbounds for i in eachindex(locs)
+        if locs[i]
+            j += 1
+            unsafe_setindex!(seq, x[j], i)
+        end
+    end
+    seq
+end
+
+function Base.setindex!(seq::BioSequence, other::BioSequence, ::Colon)
+    return setindex!(seq, other, 1:lastindex(seq))
+end
+
+function Base.setindex!(seq::BioSequence, x, ::Colon)
+    return setindex!(seq, x, 1:lastindex(seq))
+end
+
 @inline function Base.iterate(seq::BioSequence, i::Int = firstindex(seq))
     if i > lastindex(seq)
         return nothing

--- a/src/longsequences/indexing.jl
+++ b/src/longsequences/indexing.jl
@@ -18,35 +18,10 @@ end
 
 function Base.setindex!(seq::SeqOrView{A},
                         other::SeqOrView{A},
-                        locs::AbstractVector{<:Integer}) where {A}
-    @boundscheck checkbounds(seq, locs)
-    checkdimension(other, locs)
-    return unsafe_setindex!(seq, other, locs)
-end
-
-function Base.setindex!(seq::SeqOrView{A},
-                        other::SeqOrView{A},
-                        locs::AbstractVector{Bool}) where {A}
-    @boundscheck checkbounds(seq, locs)
-    checkdimension(other, locs)
-    return unsafe_setindex!(seq, other, locs)
-end
-
-function Base.setindex!(seq::SeqOrView{A},
-                        other::SeqOrView{A},
                         locs::UnitRange{<:Integer}) where {A}
     @boundscheck checkbounds(seq, locs)
     checkdimension(other, locs)
     return copyto!(seq, locs.start, other, 1, length(locs))
-end
-
-function Base.setindex!(seq::SeqOrView{A},
-			            other::SeqOrView{A}, ::Colon) where {A}
-    return setindex!(seq, other, 1:lastindex(seq))
-end
-
-function Base.setindex!(seq::SeqOrView{A}, x, ::Colon) where {A}
-    return setindex!(seq, x, 1:lastindex(seq))
 end
 
 @inline function encoded_setindex!(seq::SeqOrView{A},

--- a/src/longsequences/seqview.jl
+++ b/src/longsequences/seqview.jl
@@ -27,7 +27,7 @@ function LongSubSeq(seq::SeqOrView{A}) where {A <: Alphabet}
 	return LongSubSeq{A}(seq)
 end
 
-function LongSubSeq{A}(seq::LongSequence{A}, part::UnitRange{Int}) where {A <: Alphabet}
+function LongSubSeq{A}(seq::LongSequence{A}, part::UnitRange{<:Integer}) where {A <: Alphabet}
     @boundscheck checkbounds(seq, part)
     return LongSubSeq{A}(seq.data, part)
 end

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -243,6 +243,27 @@ end
     end
 end
 
+@testset "Join" begin
+    function test_join(::Type{T}, seqs, result) where T
+        @test join(T, seqs) == result
+        @test join!(T(), seqs) == result
+    end
+
+    base_seq = dna"TGATGCTAVWMMKACGAS" # used for seqviews in testing
+    test_join(LongDNASeq, [dna"TACG", mer"ACCTGT", @view(base_seq[16:18])], dna"TACGACCTGTGAS")
+    test_join(LongRNASeq, Set([]), LongRNASeq())
+
+    base_aa_seq = aa"KMAEEHPAIYWLMN"
+    test_join(LongAminoAcidSeq, (aa"KMVLE", aa"", (@view base_aa_seq[3:6])), aa"KMVLEAEEH")
+
+    test_join(LongSequence{DNAAlphabet{2}},
+        Iterators.filter(x -> true, map(each(DNAMer{3}, dna"ACGTAGC")) do kmer
+            kmer.fw
+        end),
+        LongSequence{DNAAlphabet{2}}("ACGCGTGTATAGAGC")
+    )
+end
+
 @testset "Length" begin
     for len in [0, 1, 2, 3, 10, 16, 32, 1000, 10000]
         seq = LongDNASeq(random_dna(len))

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -247,6 +247,8 @@ end
     function test_join(::Type{T}, seqs, result) where T
         @test join(T, seqs) == result
         @test join!(T(), seqs) == result
+        long_seq = T(1000)
+        @test join!(long_seq, seqs) == result
     end
 
     base_seq = dna"TGATGCTAVWMMKACGAS" # used for seqviews in testing


### PR DESCRIPTION
I've wanted this for a while. Here's how it works:

```julia
julia> join(LongRNASeq, [rna"AUG", rna"ACG", rna"UAA"])
9nt RNA Sequence:
AUGACGUAA

# Arbitrary sequences (also arbitrary iterables)
julia> join(LongSequence{DNAAlphabet{2}},
           (dna"ACGG", mer"ACG", view(dna"TAG", 1:2), ReferenceSequence("AC")))
11nt DNA Sequence:
ACGGACGTAAC

# Also has an in-place version to avoid allocations
julia> aaseq = aa"MYH";

julia> join!(aaseq, [aa"KK", aa"NIS"]);

julia> aaseq
5aa Amino Acid Sequence:
KKNIS
```

Note that this requires #133 to work, so I'll merge that one first. But I'll let them both sit for a while.