### PR TITLE
Change semantics of find to match Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Removed composition functionality
 * Removed ReferenceSequence functionality
 * Removed demultiplexer functionality
+* Exact sequence search for single biosymbols have been removed. Instead of `findfirst(DNA_A, my_seq)`, use `findfirst(isequal(DNA_A), my_seq)`.
+
+### Changed
 
 ## [Unreleased]
 ### Added

--- a/docs/src/sequence_search.md
+++ b/docs/src/sequence_search.md
@@ -18,13 +18,19 @@ are considered.
 
 ## Exact search
 
-Exact search functions search for an occurrence of the query symbol or
-sequence.
+Similar to other Julia sequences like `Vector`, a `BioSequence` can be searched using a function. This returns the index of the element matching where the function returns `true`, or `nothing` if no elements were found:
+
+```jldoctest
+julia> findfirst(isequal(DNA_A), dna"GCTTAG")
+5
+
+julia> findfirst(isequal(DNA_M), dna"GCTTAG") === nothing
+true
+```
+
+Sequences may also be effectively searched for the occurence of subsequences:
 ```jldoctest
 julia> seq = dna"ACAGCGTAGCT";
-
-julia> findfirst(DNA_G, seq)
-4
 
 julia> query = dna"AGC";
 
@@ -52,15 +58,6 @@ julia> findfirst(dna"CNT", dna"ACGT")  # 'G' matches 'N'
 
 julia> occursin(dna"CNT", dna"ACNT")
 true
-```
-
-The exception to this behaviour is if you are finding a single 'character',
-in which case an ambiguous symbol is matched exactly:
-
-```jldoctest
-julia> findfirst(DNA_N, dna"ACNT")
-3
-
 ```
 
 The exact sequence search needs a preprocessing phase of query sequence before
@@ -160,8 +157,7 @@ false
 
 ```
 
-`match` will return a `RegexMatch` if a match is found, otherwise it will return
-`nothing` if no match is found.
+`match` will return a `RegexMatch` if a match is found, otherwise it will return `nothing` if no match is found.
 
 The table below summarizes available syntax elements.
 
@@ -286,6 +282,7 @@ julia> pwm = PWM(pfm .+ 0.01, prior=[0.2, 0.3, 0.3, 0.2])  # GC-rich prior
 
 The ``PWM_{s,j}`` matrix is computed from ``PFM_{s,j}`` and the prior
 probability ``p(s)`` as follows ([Wasserman2004]):
+
 ```math
 \begin{align}
     PWM_{s,j} &= \log_2 \frac{p(s,j)}{p(s)} \\

--- a/src/biosequence/find.jl
+++ b/src/biosequence/find.jl
@@ -7,18 +7,8 @@
 ### This file is a part of BioJulia.
 ### License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
-function Base.findnext(val, seq::BioSequence, start::Integer)
-    checkbounds(seq, start)
-    v = convert(eltype(seq), val)
-    for i in start:lastindex(seq)
-        if inbounds_getindex(seq, i) == v
-            return i
-        end
-    end
-    return nothing
-end
-
 function Base.findnext(f::Function, seq::BioSequence, start::Integer)
+    start > lastindex(seq) && return nothing
     checkbounds(seq, start)
     for i in start:lastindex(seq)
         if f(inbounds_getindex(seq, i))
@@ -31,18 +21,8 @@ end
 # No ambiguous sites can exist in a nucleic acid sequence using the two-bit alphabet.
 Base.findnext(::typeof(isambiguous), seq::BioSequence{<:NucleicAcidAlphabet{2}}, from::Integer) = nothing
 
-function Base.findprev(val, seq::BioSequence, start::Integer)
-    checkbounds(seq, start)
-    v = convert(eltype(seq), val)
-    for i in start:-1:1
-        if inbounds_getindex(seq, i) == v
-            return i
-        end
-    end
-    return nothing
-end
-
 function Base.findprev(f::Function, seq::BioSequence, start::Integer)
+    start < firstindex(seq) && return nothing
     checkbounds(seq, start)
     for i in start:-1:firstindex(seq)
         if f(inbounds_getindex(seq, i))
@@ -52,6 +32,5 @@ function Base.findprev(f::Function, seq::BioSequence, start::Integer)
     return nothing
 end
 
-Base.findfirst(val, seq::BioSequence) = findnext(val, seq, 1)
-Base.findlast(val, seq::BioSequence) = findprev(val, seq, lastindex(seq))
-
+Base.findfirst(f::Function, seq::BioSequence) = findnext(f, seq, 1)
+Base.findlast(f::Function, seq::BioSequence) = findprev(f, seq, lastindex(seq))

--- a/src/biosequence/indexing.jl
+++ b/src/biosequence/indexing.jl
@@ -118,6 +118,9 @@ Base.size(seq::BioSequence) = (length(seq),)
 Base.firstindex(seq::BioSequence) = 1
 Base.lastindex(seq::BioSequence) = length(seq)
 Base.eachindex(seq::BioSequence) = Base.OneTo(lastindex(seq))
+Base.keys(seq::BioSequence) = eachindex(seq)
+Base.nextind(::BioSequence, i::Integer) = Int(i) + 1
+Base.prevind(::BioSequence, i::Integer) = Int(i) - 1
 
 # Bounds checking...
 @inline function Base.checkbounds(seq::BioSequence, i::Integer)

--- a/src/longsequences/counting.jl
+++ b/src/longsequences/counting.jl
@@ -6,7 +6,6 @@
 
 # Counting GC positions
 let
-    @info "Compiling bit-parallel GC counter for LongSequence{<:NucleicAcidAlphabet}"
     counter = :(n += gc_bitcount(chunk, BitsPerSymbol(seq)))
     compile_bitpar(
         :count_gc_bitpar,
@@ -23,8 +22,6 @@ Base.count(::typeof(isGC), seq::SeqOrView{<:NucleicAcidAlphabet}) = count_gc_bit
 
 # Counting mismatches
 let
-    @info "Compiling bit-parallel mismatch counter for LongSequence{<:NucleicAcidAlphabet}"
-    
     counter = :(count += mismatch_bitcount(x, y, A()))
     
     compile_2seq_bitpar(
@@ -43,8 +40,6 @@ Base.count(::typeof(!=), seqa::NucleicSeqOrView, seqb::NucleicSeqOrView) = count
 
 # Counting matches
 let
-    @info "Compiling bit-parallel match counter for LongSequence{<:NucleicAcidAlphabet}"
-    
     counter = :(count += match_bitcount(x, y, A()))
     
     count_empty = quote
@@ -70,9 +65,6 @@ Base.count(::typeof(==), seqa::NucleicSeqOrView, seqb::NucleicSeqOrView) = count
 # Counting ambiguous sites
 # ------------------------
 let
-    @info "Compiling bit-parallel ambiguity counter..."
-    @info "\tFor a single LongSequence{<:NucleicAcidAlphabet}"
-    
     counter = :(count += ambiguous_bitcount(chunk, Alphabet(seq)))
     
     compile_bitpar(
@@ -84,8 +76,6 @@ let
         tail_code   = counter,
         return_code = :(return count)
     ) |> eval
-    
-    @info "\tFor a pair of LongSequence{<:NucleicAcidAlphabet}s"
     
     counter = :(count += ambiguous_bitcount(x, y, A()))
     
@@ -116,8 +106,6 @@ Base.count(::typeof(isambiguous), seqa::SeqOrView{<:NucleicAcidAlphabet{2}}, seq
 
 # Counting certain sites
 let
-    @info "Compiling bit-parallel certainty counter for LongSequence{<:NucleicAcidAlphabet}"
-    
     counter = :(count += certain_bitcount(x, y, A()))
     
     compile_2seq_bitpar(
@@ -137,8 +125,6 @@ Base.count(::typeof(iscertain), seqa::SeqOrView{<:NucleicAcidAlphabet{2}}, seqb:
 
 # Counting gap sites
 let
-    @info "Compiling bit-parallel gap counter for LongSequence{<:NucleicAcidAlphabet}"
-    
     counter = :(count += gap_bitcount(x, y, A()))
     
     count_empty = quote

--- a/src/search/re.jl
+++ b/src/search/re.jl
@@ -674,7 +674,7 @@ function Base.match(re::Regex{T}, seq::BioSequences.BioSequence, start::Integer=
     s = start
     while true
         if firstsym != BioSequences.gap(T)
-            s = findnext(firstsym, seq, s)
+            s = findnext(isequal(firstsym), seq, s)
             if s == nothing
                 break
             end

--- a/test/longsequences/find.jl
+++ b/test/longsequences/find.jl
@@ -1,31 +1,31 @@
 @testset "Find" begin
     seq = dna"ACGNA"
-    @test findnext(DNA_A, seq, 1) == 1
-    @test findnext(DNA_C, seq, 1) == 2
-    @test findnext(DNA_G, seq, 1) == 3
-    @test findnext(DNA_N, seq, 1) == 4
-    @test findnext(DNA_T, seq, 1) == nothing
-    @test findnext(DNA_A, seq, 2) == 5
+    @test findnext(isequal(DNA_A), seq, 1) == 1
+    @test findnext(isequal(DNA_C), seq, 1) == 2
+    @test findnext(isequal(DNA_G), seq, 1) == 3
+    @test findnext(isequal(DNA_N), seq, 1) == 4
+    @test findnext(isequal(DNA_T), seq, 1) === nothing
+    @test findnext(isequal(DNA_A), seq, 2) == 5
 
-    @test_throws BoundsError findnext(DNA_A, seq, 0)
-    @test_throws BoundsError findnext(DNA_A, seq, 6)
+    @test_throws BoundsError findnext(isequal(DNA_A), seq, 0)
+    @test findnext(isequal(DNA_A), seq, 6) === nothing
 
-    @test findprev(DNA_A, seq, 4) == 1
-    @test findprev(DNA_C, seq, 4) == 2
-    @test findprev(DNA_G, seq, 4) == 3
-    @test findprev(DNA_N, seq, 4) == 4
-    @test findprev(DNA_T, seq, 4) == nothing
-    @test findprev(DNA_G, seq, 2) == nothing
+    @test findprev(isequal(DNA_A), seq, 4) == 1
+    @test findprev(isequal(DNA_C), seq, 4) == 2
+    @test findprev(isequal(DNA_G), seq, 4) == 3
+    @test findprev(isequal(DNA_N), seq, 4) == 4
+    @test findprev(isequal(DNA_T), seq, 4) === nothing
+    @test findprev(isequal(DNA_G), seq, 2) === nothing
 
-    @test_throws BoundsError findprev(DNA_A, seq, 0)
-    @test_throws BoundsError findprev(DNA_A, seq, 6)
+    @test findprev(isequal(DNA_A), seq, 0) === nothing
+    @test_throws BoundsError findprev(isequal(DNA_A), seq, 6)
 
     seq = dna"ACGNAN"
-    @test findfirst(DNA_A, seq) == 1
-    @test findfirst(DNA_N, seq) == 4
-    @test findfirst(DNA_T, seq) == nothing
+    @test findfirst(isequal(DNA_A), seq) == 1
+    @test findfirst(isequal(DNA_N), seq) == 4
+    @test findfirst(isequal(DNA_T), seq) === nothing
 
-    @test findlast(DNA_A, seq) == 5
-    @test findlast(DNA_N, seq) == 6
-    @test findlast(DNA_T, seq) == nothing
+    @test findlast(isequal(DNA_A), seq) == 5
+    @test findlast(isequal(DNA_N), seq) == 6
+    @test findlast(isequal(DNA_T), seq) === nothing
 end

--- a/test/mers/find.jl
+++ b/test/mers/find.jl
@@ -2,49 +2,49 @@
     kmer = DNAMer("ACGAG")
     bigkmer = BigDNAMer("ACGAG")
 
-    @test findnext(DNA_A, kmer, 1) == 1
-    @test findnext(DNA_C, kmer, 1) == 2
-    @test findnext(DNA_G, kmer, 1) == 3
-    @test findnext(DNA_T, kmer, 1) == nothing
-    @test findnext(DNA_A, kmer, 2) == 4
+    @test findnext(isequal(DNA_A), kmer, 1) == 1
+    @test findnext(isequal(DNA_C), kmer, 1) == 2
+    @test findnext(isequal(DNA_G), kmer, 1) == 3
+    @test findnext(isequal(DNA_T), kmer, 1) === nothing
+    @test findnext(isequal(DNA_A), kmer, 2) == 4
     
-    @test findnext(DNA_A, bigkmer, 1) == 1
-    @test findnext(DNA_C, bigkmer, 1) == 2
-    @test findnext(DNA_G, bigkmer, 1) == 3
-    @test findnext(DNA_T, bigkmer, 1) == nothing
-    @test findnext(DNA_A, bigkmer, 2) == 4
+    @test findnext(isequal(DNA_A), bigkmer, 1) == 1
+    @test findnext(isequal(DNA_C), bigkmer, 1) == 2
+    @test findnext(isequal(DNA_G), bigkmer, 1) == 3
+    @test findnext(isequal(DNA_T), bigkmer, 1) === nothing
+    @test findnext(isequal(DNA_A), bigkmer, 2) == 4
 
-    @test_throws BoundsError findnext(DNA_A, kmer, 0)
-    @test_throws BoundsError findnext(DNA_A, kmer, 6)
+    @test_throws BoundsError findnext(isequal(DNA_A), kmer, 0)
+    @test findnext(isequal(DNA_A), kmer, 6) === nothing
     
-    @test_throws BoundsError findnext(DNA_A, bigkmer, 0)
-    @test_throws BoundsError findnext(DNA_A, bigkmer, 6)
+    @test_throws BoundsError findnext(isequal(DNA_A), bigkmer, 0)
+    @test findnext(isequal(DNA_A), bigkmer, 6) === nothing
 
-    @test findprev(DNA_A, kmer, 5) == 4
-    @test findprev(DNA_C, kmer, 5) == 2
-    @test findprev(DNA_G, kmer, 5) == 5
-    @test findprev(DNA_T, kmer, 5) == nothing
-    @test findprev(DNA_G, kmer, 4) == 3
+    @test findprev(isequal(DNA_A), kmer, 5) == 4
+    @test findprev(isequal(DNA_C), kmer, 5) == 2
+    @test findprev(isequal(DNA_G), kmer, 5) == 5
+    @test findprev(isequal(DNA_T), kmer, 5) === nothing
+    @test findprev(isequal(DNA_G), kmer, 4) == 3
     
-    @test findprev(DNA_A, bigkmer, 5) == 4
-    @test findprev(DNA_C, bigkmer, 5) == 2
-    @test findprev(DNA_G, bigkmer, 5) == 5
-    @test findprev(DNA_T, bigkmer, 5) == nothing
-    @test findprev(DNA_G, bigkmer, 4) == 3
+    @test findprev(isequal(DNA_A), bigkmer, 5) == 4
+    @test findprev(isequal(DNA_C), bigkmer, 5) == 2
+    @test findprev(isequal(DNA_G), bigkmer, 5) == 5
+    @test findprev(isequal(DNA_T), bigkmer, 5) === nothing
+    @test findprev(isequal(DNA_G), bigkmer, 4) == 3
 
-    @test_throws BoundsError findprev(DNA_A, kmer, 0)
-    @test_throws BoundsError findprev(DNA_A, kmer, 6)
+    @test findprev(isequal(DNA_A), kmer, 0) === nothing
+    @test_throws BoundsError findprev(isequal(DNA_A), kmer, 6)
     
-    @test_throws BoundsError findprev(DNA_A, bigkmer, 0)
-    @test_throws BoundsError findprev(DNA_A, bigkmer, 6)
+    @test findprev(isequal(DNA_A), bigkmer, 0) === nothing
+    @test_throws BoundsError findprev(isequal(DNA_A), bigkmer, 6)
 
-    @test findfirst(DNA_A, kmer) == 1
-    @test findfirst(DNA_G, kmer) == 3
-    @test findlast(DNA_A, kmer) == 4
-    @test findlast(DNA_G, kmer) == 5
+    @test findfirst(isequal(DNA_A), kmer) == 1
+    @test findfirst(isequal(DNA_G), kmer) == 3
+    @test findlast(isequal(DNA_A), kmer) == 4
+    @test findlast(isequal(DNA_G), kmer) == 5
     
-    @test findfirst(DNA_A, bigkmer) == 1
-    @test findfirst(DNA_G, bigkmer) == 3
-    @test findlast(DNA_A, bigkmer) == 4
-    @test findlast(DNA_G, bigkmer) == 5
+    @test findfirst(isequal(DNA_A), bigkmer) == 1
+    @test findfirst(isequal(DNA_G), bigkmer) == 3
+    @test findlast(isequal(DNA_A), bigkmer) == 4
+    @test findlast(isequal(DNA_G), bigkmer) == 5
 end


### PR DESCRIPTION
  Remove find methods with single biosymbols

  See issue #141. Users are adviced to use `findfirst(isequal(x), seq)` instead.