### PR TITLE
Re-add construction between integer/kmer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Removed composition functionality
 * Removed ReferenceSequence functionality
 * Removed demultiplexer functionality
-* AbstractMers can no longer be instantiated from, or converted to or from integers. Users should instead use the explicit `masked(T, x::UInt)` to create k-mers from integers.
+* AbstractMers can no longer be converted to or from integers.
+* Removed kmer artihmetic.
+* When constructing mers from integers, the constructor now checks for overflow. To skip the check, use the explicit `masked(T, x::UInt)` to create k-mers from integers.
 * Exact sequence search for single biosymbols have been removed. Instead of `findfirst(DNA_A, my_seq)`, use `findfirst(isequal(DNA_A), my_seq)`.
 
 ### Added

--- a/src/mers/conversion.jl
+++ b/src/mers/conversion.jl
@@ -32,6 +32,12 @@ function (::Type{T})(seq) where {T<:AbstractMer}
     return reinterpret(T, x)
 end
 
+(::Type{T})(i::Signed) where {T<:AbstractMer} = T(unsigned(i))
+(::Type{T})(i::Unsigned) where {T<:AbstractMer} = T(encoded_data_type(T)(i))
+
+UInt64(x::Mer) = reinterpret(UInt64, x)
+UInt128(x::BigMer) = reinterpret(UInt128, x)
+
 (::Type{Mer{A}})(seq) where {A} = Mer{A,length(seq)}(seq)
 (::Type{BigMer{A}})(seq) where {A} = BigMer{A,length(seq)}(seq)
 

--- a/src/mers/mer.jl
+++ b/src/mers/mer.jl
@@ -85,6 +85,20 @@ end
 
 Alphabet(::Type{Mer{A,K} where A<:NucleicAcidAlphabet{2}}) where {K} = Any
 
+function Mer{A,K}(x::UInt64) where {A,K}
+    checkmer(Mer{A,K})
+    maxval = (one(UInt64) << (2 * K)) - 1
+    x > maxval && throw(DomainError(x, "Mer with K=$K is too small for $x"))
+    return reinterpret(Mer{A,K}, x)
+end
+
+function BigMer{A,K}(x::UInt128) where {A,K}
+    checkmer(BigMer{A,K})
+    maxval = (one(UInt128) << (2 * K)) - 1
+    x > maxval && throw(DomainError(x, "Mer with K=$K is too small for $x"))
+    return reinterpret(BigMer{A,K}, x)
+end
+
 ###
 ### Conversion
 ###

--- a/test/mers/conversion.jl
+++ b/test/mers/conversion.jl
@@ -62,7 +62,7 @@ global reps = 10
                 @test all(Bool[check_roundabout_construction(RNAMer{len}, RNAAlphabet{2}, random_rna_kmer(len)) for _ in 1:reps])
                 @test all(Bool[check_roundabout_construction(RNAMer{len}, RNAAlphabet{4}, random_rna_kmer(len)) for _ in 1:reps])
             end
-            
+
             # String construction
             @test all(Bool[check_string_construction(BigDNAMer{len}, random_dna_kmer(len)) for _ in 1:reps])
             @test all(Bool[check_string_construction(BigRNAMer{len}, random_rna_kmer(len)) for _ in 1:reps])
@@ -82,6 +82,26 @@ global reps = 10
             @test all(Bool[check_roundabout_construction(BigRNAMer{len}, RNAAlphabet{4}, random_rna_kmer(len)) for _ in 1:reps])
         end
     end
+
+    # Construction from UInt
+    @test DNAMer{4}(0xf1) == mer"TTAC"
+    @test BigDNAMer{4}(0xfa) == mer"TTGG"
+    @test RNAMer{3}(UInt(7)) == mer"ACU"rna
+
+    # Overflow
+    @test_throws DomainError DNAMer{4}(0xffff)
+    @test_throws DomainError RNAMer{4}(0x1000001)
+    @test_throws DomainError BigDNAMer{20}(0x1234567890abcdef)
+
+    # Construction from Int
+    @test DNAMer{2}(9) == mer"GC"
+    @test BigDNAMer{6}(1) == mer"AAAAAC"
+    @test RNAMer{3}(0) == mer"AAA"rna
+
+    # Construction of int from Mer
+    @test UInt64(mer"TCC") == UInt(0b110101)
+    @test UInt64(mer"AAACU"rna) == UInt(0b0000000111)
+    @test UInt128(BigRNAMer{11}(19)) == UInt(19)
 
     @test_throws MethodError Mer() # can't construct 0-mer using `Kmer()`
     @test_throws MethodError BigMer() # can't construct 0-mer using `BigKmer()`


### PR DESCRIPTION
* Conversion is still not permitted
* Construction of kmers from integers checks for overflow
* To skip the overflow check and instead mask unused bits, use the `masked` function.
* Documented the removal of kmer arithmetic