### PR TITLE
Remove financial backing and Gitter from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![MIT license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://biojulia.github.io/BioSequences.jl/stable)
 [![Pkg Status](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
-[![Chat](https://img.shields.io/gitter/room/BioJulia/BioSequences.svg)](https://gitter.im/BioJulia/BioSequences.jl)
-
 
 ## Description
 
@@ -44,27 +42,9 @@ Take a look at the [contributing files](https://github.com/BioJulia/Contributing
 detailed contributor and maintainer guidelines, and code of conduct.
 
 
-
-### Financial contributions
-
-We also welcome financial contributions in full transparency on our
-[open collective](https://opencollective.com/biojulia).
-Anyone can file an expense. If the expense makes sense for the development
-of the community, it will be "merged" in the ledger of our open collective by
-the core contributors and the person who filed the expense will be reimbursed.
-
-
 ## Backers & Sponsors
 
 Thank you to all our backers and sponsors!
-
-Love our work and community? [Become a backer](https://opencollective.com/biojulia#backer).
-
-[![backers](https://opencollective.com/biojulia/backers.svg?width=890)](https://opencollective.com/biojulia#backers)
-
-Does your company use BioJulia? Help keep BioJulia feature rich and healthy by
-[sponsoring the project](https://opencollective.com/biojulia#sponsor)
-Your logo will show up here with a link to your website.
 
 [![](https://opencollective.com/biojulia/sponsor/0/avatar.svg)](https://opencollective.com/biojulia/sponsor/0/website)
 [![](https://opencollective.com/biojulia/sponsor/1/avatar.svg)](https://opencollective.com/biojulia/sponsor/1/website)
@@ -81,5 +61,5 @@ Your logo will show up here with a link to your website.
 ## Questions?
 
 If you have a question about contributing or using BioJulia software, come
-on over and chat to us on [Gitter](https://gitter.im/BioJulia/General), or you can try the
+on over and chat to us on [the Julia Slack workspace](https://julialang.org/slack/), or you can try the
 [Bio category of the Julia discourse site](https://discourse.julialang.org/c/domain/bio).


### PR DESCRIPTION
This is a pretty intrusive PR, so I'll leave it up for until May 1st at least (and also, cc @BenJWard, @kescobo, @pdimens - your input is important).

I've removed links to the OpenCollective and to Gitter from the README.

The issue is two fold:
* The BioJulia Gitter is dead. The last post in there was 2 months ago (a question with no answers) - the once before that, four months ago. Directing people to a dead forum where they can post question to months of silence is much worse than just not directing them anywhere.
* BioJulia asks for money from people, and currently have 1500 $, but has no expenses, since everything is provided by GitHub and CodeCov for free. I feel we really shouldn't ask for people's money just for it to sit around, doing nothing.

I'm planning on repeating this PR for all major BioJulia repos.