### PR TITLE
Add findfirst method for BioSymbol

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Ben J. Ward <benjward@protonmail.com>"]
 version = "3.0.0"
 
 [deps]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Ben J. Ward <benjward@protonmail.com>"]
 version = "3.0.0"
 
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"

--- a/src/search/exact.jl
+++ b/src/search/exact.jl
@@ -111,6 +111,24 @@ function Base.findfirst(pat::BioSequence, seq::BioSequence,
     return findfirst(ExactSearchQuery(pat), seq, start, stop)
 end
 
+"""
+    findfirst(symbol::BioSymbol, seq::BioSequence, [, start=1[, stop=lastindex(seq)]])
+
+Return the index of the first occurrence of the symbol in the sequence; symbol
+comparison is done using `BioSequences.iscompatible`.
+"""
+function Base.findfirst(symbol::BioSymbol, seq::BioSequence,
+                        start::Integer=1, stop::Integer=lastindex(seq))
+    if eltype(seq) != typeof(symbol)
+        throw(ArgumentError("the element type of sequence must be $(typeof(symbol))"))
+    end
+    checkbounds(seq, start:stop)
+    @inbounds for i in start:stop
+        iscompatible(symbol, seq[i]) && return i
+    end
+    return nothing
+end
+
 function Base.findfirst(query::ExactSearchQuery, seq::BioSequence,
                         start::Integer=1, stop::Integer=lastindex(seq))
     checkeltype(seq, query.seq)
@@ -180,6 +198,24 @@ comparison is done using `BioSequences.iscompatible`.
 function Base.findlast(pat::BioSequence, seq::BioSequence,
                        start::Integer=lastindex(seq), stop::Integer=1)
     return findlast(ExactSearchQuery(pat), seq, start, stop)
+end
+
+"""
+    findlast(symbol::BioSymbol, seq::BioSequence, [, start=1[, stop=lastindex(seq)]])
+
+Return the index of the last occurrence of the symbol in the sequence; symbol
+comparison is done using `BioSequences.iscompatible`.
+"""
+function Base.findlast(symbol::BioSymbol, seq::BioSequence,
+                        start::Integer=1, stop::Integer=lastindex(seq))
+    if eltype(seq) != typeof(symbol)
+        throw(ArgumentError("the element type of sequence must be $(typeof(symbol))"))
+    end
+    checkbounds(seq, start:stop)
+    @inbounds for i in stop:-1:start
+        iscompatible(symbol, seq[i]) && return i
+    end
+    return nothing
 end
 
 function Base.findlast(query::ExactSearchQuery, seq::BioSequence,

--- a/test/search/exact.jl
+++ b/test/search/exact.jl
@@ -12,6 +12,13 @@
         @test findfirst(dna"ACG", seq, 2) === 5:7
         @test findfirst(seq, seq) === 1:lastindex(seq)
 
+        @test findfirst(DNA_A, dna"AAACT") == 1
+        @test findfirst(DNA_C, dna"") === nothing
+        @test findfirst(DNA_M, dna"TGC") == 3
+        @test findfirst(DNA_N, dna"T") == 1
+        @test findfirst(DNA_V, dna"TTTT") === nothing
+        @test findfirst(DNA_C, seq) == 2
+
         @test findfirst(dna"", dna"") === 1:0
         @test findfirst(dna"", dna"", -1) === 1:0
         @test findfirst(dna"", dna"", 2) === nothing
@@ -40,6 +47,12 @@
         @test findlast(dna"ACG", seq) === 5:7
         @test findlast(dna"ACG", seq, 6) === 1:3
         @test findlast(seq, seq) === 1:lastindex(seq)
+
+        @test findlast(DNA_A, seq) == 5
+        @test findlast(DNA_T, seq) == 4
+        @test findlast(DNA_N, dna"") === nothing
+        @test findlast(DNA_R, dna"AGTCAGTTCT") == 6
+        @test findlast(DNA_R, dna"TCTCTT") === nothing
 
         @test findlast(dna"", dna"") === 1:0
         @test findlast(dna"", dna"", 2) === 1:0


### PR DESCRIPTION
See #141

This PR adds `findfirst` and `findlast` methods of the type `findfirst(::BioSymbol, ::BioSequence)`. How it currently works is:
* `findfirst(::BioSymbol, ::BioSequence)` allows for compatible but different symbols, i.e. `dna"TACNA"` has a potential `G` at position 4. This is the new thing in the PR.
* `findfirst(::BioSequence, ::BioSequence)` likewise allows compatible symbols, just like before.
* To get literal match against a symbol, do `findfirst(isequal(DNA_A), dna"GGA")`
* There is currently no way to search for literal matches between two biological sequences. Perhaps there should be, but I'm not sure what the syntax should be.

Issues / things to mull over:
* Currently, search uses `compatbits` for the element `BioSymbol` type, and this is not generically defined for user-defined biosymbols (see https://github.com/BioJulia/BioSymbols.jl/issues/42).
* There is no way to search for literal biosequence matches.