### PR TITLE
Export RE.Regex and RE.RegexMatch as BioRegex and BioRegexMatch

### DIFF
--- a/docs/src/sequence_search.md
+++ b/docs/src/sequence_search.md
@@ -135,6 +135,10 @@ julia> approxsearch(dna"ACTACGT", query, 2)
 Query patterns can be described in regular expressions. The syntax supports
 a subset of Perl and PROSITE's notation.
 
+Biological regexes can be constructed using the `BioRegex` constructor, for
+example by doing `BioRegex{AminoAcid}("MV+")`. For bioregex literals, it is
+instead recommended using the `@biore_str` macro:
+
 The Perl-like syntax starts with `biore` (BIOlogical REgular expression)
 and ends with a symbol option: "dna", "rna" or "aa". For example, `biore"A+"dna`
 is a regular expression for DNA sequences and `biore"A+"aa` is for amino acid

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -161,6 +161,8 @@ export
     @biore_str,
     @prosite_str,
     
+    BioRegex,
+    BioRegexMatch,
     matched,
     captured,
     alphabet, # TODO: Resolve the use of alphabet - it's from BioSymbols.jl

--- a/test/search/regex.jl
+++ b/test/search/regex.jl
@@ -1,4 +1,12 @@
 @testset "Regular Expression" begin
+    # First test the biore syntax works as intended
+    @test biore"A+[CG]N"d == BioRegex{DNA}("A+[CG]N")
+    @test biore"A+[CG]N"d != BioRegex{DNA}("A*[CG]N")
+    @test biore"MV?(I|L)W{3,5}$"a == BioRegex{AminoAcid}("MV?(I|L)W{3,5}\$")
+    @test biore"MV?(I|L)W{3,5}$"a != BioRegex{AminoAcid}("MV?(I|L)W{3,4}\$")
+    @test biore"A+UUC*"r == BioRegex{RNA}("A+UUC*")
+    @test biore"A+UC*"r != BioRegex{RNA}("A+UUC*")
+
     @test isa(biore"A+"d, BioSequences.RE.Regex{DNA})
     @test isa(biore"A+"r, BioSequences.RE.Regex{RNA})
     @test isa(biore"A+"a, BioSequences.RE.Regex{AminoAcid})


### PR DESCRIPTION
Fix for issue #167, by creating the new type aliases `const BioRegex = RE.Regex` and `const BioRegexMatch = RE.RegexMatch`, and exports them. No breaking changes.

Also improve some docstrings.