### PR TITLE
Approximate search now returns nothing when no match is found

### DIFF
--- a/docs/src/sequence_search.md
+++ b/docs/src/sequence_search.md
@@ -89,7 +89,6 @@ sequence:
 julia> seq = dna"ACAGCGTAGCT";
 
 julia> approxsearch(seq, dna"AGGG", 0)  # nothing matches with no errors
-0:-1
 
 julia> approxsearch(seq, dna"AGGG", 1)  # seq[3:6] matches with one error
 3:6

--- a/test/search/approximate.jl
+++ b/test/search/approximate.jl
@@ -5,11 +5,11 @@
         @test approxsearch(seq, dna"", 0) === 1:0
         @test approxsearch(seq, dna"AC", 0) === 1:2
         @test approxsearch(seq, dna"AC", 0, 2) === 5:6
-        @test approxsearch(seq, dna"AC", 0, 2, 5) === 0:-1
-        @test approxsearch(seq, dna"AT", 0) === 0:-1
+        @test approxsearch(seq, dna"AC", 0, 2, 5) === nothing
+        @test approxsearch(seq, dna"AT", 0) === nothing
         @test approxsearch(seq, dna"AT", 1) === 1:1
         @test approxsearch(seq, dna"AT", 1, 2) === 3:4
-        @test approxsearch(seq, dna"AT", 1, 2, 3) === 0:-1
+        @test approxsearch(seq, dna"AT", 1, 2, 3) === nothing
         @test approxsearch(seq, dna"NG", 0) === 2:3
         @test approxsearch(seq, dna"NG", 1) === 1:1
         @test approxsearch(seq, dna"GN", 0) === 3:4
@@ -17,21 +17,21 @@
         @test approxsearch(seq, dna"ACG", 0) === 1:3
         @test approxsearch(seq, dna"ACG", 1) === 1:2
         @test approxsearch(seq, dna"ACG", 2) === 1:1
-        @test approxsearch(seq, dna"ACG", 3) === 1:0
-        @test approxsearch(seq, dna"ACG", 4) === 1:0
+        @test approxsearch(seq, dna"ACG", 3) === nothing
+        @test approxsearch(seq, dna"ACG", 4) === nothing
 
         @test approxsearchindex(seq, dna"", 0) === 1
         @test approxsearchindex(seq, dna"AC", 0) === 1
         @test approxsearchindex(seq, dna"AC", 0, 2) === 5
-        @test approxsearchindex(seq, dna"AC", 0, 2, 5) === 0
+        @test approxsearchindex(seq, dna"AC", 0, 2, 5) === nothing
 
         query = ApproximateSearchQuery(dna"ACG")
         @test approxsearch(seq, query, 1) === 1:2
         @test approxsearch(seq, query, 1, 2) === 2:3
-        @test approxsearch(seq, query, 1, 2, 2) === 0:-1
+        @test approxsearch(seq, query, 1, 2, 2) === nothing
         @test approxsearchindex(seq, query, 1) === 1
         @test approxsearchindex(seq, query, 1, 2) === 2
-        @test approxsearchindex(seq, query, 1, 2, 2) === 0
+        @test approxsearchindex(seq, query, 1, 2, 2) === nothing
     end
 
     @testset "backward" begin
@@ -39,12 +39,12 @@
         @test approxrsearch(seq, dna"", 0) === 7:6
         @test approxrsearch(seq, dna"AC", 0) === 5:6
         @test approxrsearch(seq, dna"AC", 0, 5) === 1:2
-        @test approxrsearch(seq, dna"AC", 0, 5, 2) === 0:-1
-        @test approxrsearch(seq, dna"AT", 0) === 0:-1
+        @test approxrsearch(seq, dna"AC", 0, 5, 2) === nothing
+        @test approxrsearch(seq, dna"AT", 0) === nothing
         @test approxrsearch(seq, dna"AT", 1) === 5:6
         @test approxrsearch(seq, dna"AT", 1, 6) === 5:6
         @test approxrsearch(seq, dna"AT", 1, 5) === 5:5
-        @test approxrsearch(seq, dna"AT", 1, 3, 2) === 0:-1
+        @test approxrsearch(seq, dna"AT", 1, 3, 2) === nothing
         @test approxrsearch(seq, dna"NG", 0) === 6:7
         @test approxrsearch(seq, dna"NG", 0, 6) === 2:3
         @test approxrsearch(seq, dna"GN", 0) === 3:4
@@ -52,21 +52,21 @@
         @test approxrsearch(seq, dna"ACG", 0) === 5:7
         @test approxrsearch(seq, dna"ACG", 1) === 6:7
         @test approxrsearch(seq, dna"ACG", 2) === 7:7
-        @test approxrsearch(seq, dna"ACG", 3) === 7:6
-        @test approxrsearch(seq, dna"ACG", 4) === 7:6
+        @test approxrsearch(seq, dna"ACG", 3) === nothing
+        @test approxrsearch(seq, dna"ACG", 4) === nothing
 
         # TODO: maybe this should return 8 like rsearchindex
         @test approxrsearchindex(seq, dna"", 0) === 7
         @test approxrsearchindex(seq, dna"AC", 0) === 5
         @test approxrsearchindex(seq, dna"AC", 0, 5) === 1
-        @test approxrsearchindex(seq, dna"AC", 0, 5, 2) === 0
+        @test approxrsearchindex(seq, dna"AC", 0, 5, 2) === nothing
 
         query = ApproximateSearchQuery(dna"ACG")
         @test approxrsearch(seq, query, 1, 7) === 6:7
         @test approxrsearch(seq, query, 1, 6) === 5:6
-        @test approxrsearch(seq, query, 1, 6, 6) === 0:-1
+        @test approxrsearch(seq, query, 1, 6, 6) === nothing
         @test approxrsearchindex(seq, query, 1, 7) === 6
         @test approxrsearchindex(seq, query, 1, 6) === 5
-        @test approxrsearchindex(seq, query, 1, 6, 6) === 0
+        @test approxrsearchindex(seq, query, 1, 6, 6) === nothing
     end
 end


### PR DESCRIPTION
Approximate search functions now return `nothing` when no match is found. These are:
* `approxsearch`
* `approxrsearch`
* `approxsearchindex`
* `approxrsearchindex`

Behaviour is otherwise unaltered. Specifically, search for an empty sequence is valid, and returns an empty range, just like before. Weird, but it's consistent with how string search works in Base.