### PR TITLE
Fix doctests after type alias renaming

### DIFF
--- a/docs/src/construction.md
+++ b/docs/src/construction.md
@@ -17,7 +17,7 @@ types in BioSequences.
 Sequences can be constructed from strings using their constructors:
 
 ```jldoctest
-julia> LongDNASeq("TTANC")
+julia> LongDNA{4}("TTANC")
 5nt DNA Sequence:
 TTANC
 
@@ -25,7 +25,7 @@ julia> LongSequence{DNAAlphabet{2}}("TTAGC")
 5nt DNA Sequence:
 TTAGC
 
-julia> LongRNASeq("UUANC")
+julia> LongRNA{4}("UUANC")
 5nt RNA Sequence:
 UUANC
 
@@ -55,31 +55,12 @@ julia> LongRNA{2}("UUAGC")
 UUAGC
 ```
 
-!!! note 
-    From version 2.0 onwards, the `convert` methods for converting a
-    string or vector of symbols into a sequence type have been removed. These
-    convert methods did nothing but pass their arguments to the appropriate
-    constructor.
-    
-    These specific `convert` methods have been removed due to the semantics of
-    `convert`: Even though `convert(LongDNASeq, "ATCG")` was previously the same
-    as `LongDNASeq("ATCG")`, unlike constructors, `convert` is sometimes
-    implicitly called. So it's methods should be restricted to cases that are
-    considered safe or unsurprising. `convert` should convert between types that
-    represent the same basic kind of thing, like different representations of
-    numbers. It is also usually lossless. Not all strings are valid sequences,
-    and depending on the sequence type, not all vectors of BioSymbols are valid
-    sequences either. A string only represents the "same kind of thing" as a
-    biological sequence in some cases, so implicitly `convert`ing them to a
-    sequence type was never safe or unsurprising. These `convert` methods have
-    been renamed to `Base.parse` methods.
-
 ### Constructing sequences from arrays of BioSymbols
 
 Sequences can be constructed using vectors or arrays of a `BioSymbol` type:
 
 ```jldoctest
-julia> LongDNASeq([DNA_T, DNA_T, DNA_A, DNA_N, DNA_C])
+julia> LongDNA{4}([DNA_T, DNA_T, DNA_A, DNA_N, DNA_C])
 5nt DNA Sequence:
 TTANC
 
@@ -93,15 +74,15 @@ TTAGC
 
 You can create sequences, by concatenating other sequences together:
 ```jldoctest
-julia> LongDNASeq("ACGT") * LongDNASeq("TGCA")
+julia> LongDNA{2}("ACGT") * LongDNA{2}("TGCA")
 8nt DNA Sequence:
 ACGTTGCA
 
-julia> repeat(LongDNASeq("TA"), 10)
+julia> repeat(LongDNA{4}("TA"), 10)
 20nt DNA Sequence:
 TATATATATATATATATATA
 
-julia> LongDNASeq("TA") ^ 10
+julia> LongDNA{4}("TA") ^ 10
 20nt DNA Sequence:
 TATATATATATATATATATA
 
@@ -111,7 +92,7 @@ Sequence views (`LongSubSeq`s) are special, in that they do not own their own da
 and must be constructed from a `LongSequence` or another `LongSubSeq`:
 
 ```jdoctest
-julia> seq = LongDNASeq("TACGGACATTA")
+julia> seq = LongDNA{4}("TACGGACATTA")
 11nt DNA Sequence:
 TACGGACATTA
 
@@ -137,7 +118,7 @@ julia> dna = dna"TTANGTAGACCG"
 12nt DNA Sequence:
 TTANGTAGACCG
 
-julia> rna = convert(LongRNASeq, dna)
+julia> rna = convert(LongRNA{4}, dna)
 12nt RNA Sequence:
 UUANGUAGACCG
 

--- a/docs/src/sequence_search.md
+++ b/docs/src/sequence_search.md
@@ -181,14 +181,14 @@ The table below summarizes available syntax elements.
 
 ```jldoctest
 julia> collect(matched(x) for x in eachmatch(biore"TATA*?"d, dna"TATTATAATTA")) # overlap
-4-element Vector{LongDNASeq}:
+4-element Vector{LongSequence{DNAAlphabet{4}}}:
  TAT  
  TAT
  TATA
  TATAA
 
 julia> collect(matched(x) for x in eachmatch(biore"TATA*"d, dna"TATTATAATTA", false)) # no overlap
-2-element Vector{LongDNASeq}:
+2-element Vector{LongSequence{DNAAlphabet{4}}}:
  TAT  
  TATAA
 
@@ -246,7 +246,7 @@ and then create a `PWM` from the `PFM` object.
 
 ```jldoctest
 julia> motifs = [dna"TTA", dna"CTA", dna"ACA", dna"TCA", dna"GTA"]
-5-element Vector{LongDNASeq}:
+5-element Vector{LongSequence{DNAAlphabet{4}}}:
  TTA
  CTA
  ACA

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -27,8 +27,8 @@ BioSequence
 Some aliases for `BioSequence` are also provided for your convenience:
 
 ```@docs
-NucleotideSeq
-AminoAcidSeq
+NucSeq
+AASeq
 ```
 
 Let's have a closer look at some of those methods that a subtype of `BioSequence`

--- a/src/geneticcode.jl
+++ b/src/geneticcode.jl
@@ -319,7 +319,7 @@ Base3  = TCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAG
 """
     translate(seq, code=standard_genetic_code, allow_ambiguous_codons=true, alternative_start=false)
 
-Translate an `LongRNASeq` or a `LongDNASeq` to an `LongAASeq`.
+Translate an `LongRNA` or a `LongDNA` to an `LongAA`.
 
 Translation uses genetic code `code` to map codons to amino acids. See
 `ncbi_trans_table` for available genetic codes.

--- a/src/longsequences/longsequence.jl
+++ b/src/longsequences/longsequence.jl
@@ -69,7 +69,7 @@ aliases for convenience.
 | `LongSequence{RNAAlphabet{N}}`      | `RNA`       | `LongRNA{N}` |
 | `LongSequence{AminoAcidAlphabet}`   | `AminoAcid` | `LongAA`     |
 
-The `LongDNASeq` and `LongRNASeq` aliases use a DNAAlphabet{4}.
+The `LongDNA` and `LongRNA` aliases use a DNAAlphabet{4}.
 
 `DNAAlphabet{4}` permits ambiguous nucleotides, and a sequence must use at least
 4 bits to internally store each element (and indeed `LongSequence` does).
@@ -95,17 +95,12 @@ mutable struct LongSequence{A <: Alphabet} <: BioSequence{A}
     end
 end
 
-#const LongNucleotideSequence = LongSequence{<:NucleicAcidAlphabet}
 "An alias for LongSequence{<:NucleicAcidAlpabet{N}}"
 const LongNuc{N} = LongSequence{<:NucleicAcidAlphabet{N}}
 
-#"An alias for LongSequence{DNAAlphabet{4}}"
-#const LongDNASeq       = LongSequence{DNAAlphabet{4}}
 "An alias for LongSequence{DNAAlphabet{N}}"
 const LongDNA{N} = LongSequence{DNAAlphabet{N}}
 
-#"An alias for LongSequence{RNAAlphabet{4}}"
-#const LongRNASeq       = LongSequence{RNAAlphabet{4}}
 "An alias for LongSequence{RNAAlphabet{N}}"
 const LongRNA{N} = LongSequence{RNAAlphabet{N}}
 

--- a/test/longsequences/conversion.jl
+++ b/test/longsequences/conversion.jl
@@ -66,7 +66,7 @@ end
     # Non-nucleotide characters should throw
     @test_throws Exception LongDNA{4}("ACCNNCATTTTTTAGATXATAG")
     @test_throws Exception LongRNA{4}("ACCNNCATTTTTTAGATXATAG")
-    @test_throws Exception LongAASeq("ATGHLMY@ZACAGNM")
+    @test_throws Exception LongAA("ATGHLMY@ZACAGNM")
 end
 
 @testset "Construction from vectors" begin


### PR DESCRIPTION
Simply fix the docstrings after type alias change in #163. I also removed a note about changes in v 2.0 in the "construction" section.