### PR TITLE
Make macro literals dynamic

### DIFF
--- a/src/longsequences/stringliterals.jl
+++ b/src/longsequences/stringliterals.jl
@@ -21,7 +21,9 @@ macro dna_str(seq, flag)
 end
 
 macro dna_str(seq)
-    return LongDNA{4}(remove_newlines(seq))
+    return quote
+        LongDNA{4}($(remove_newlines(seq)))
+    end
 end
 
 macro rna_str(seq, flag)
@@ -36,7 +38,9 @@ macro rna_str(seq, flag)
 end
 
 macro rna_str(seq)
-    return LongRNA{4}(remove_newlines(seq))
+    return quote
+        LongRNA{4}($(remove_newlines(seq)))
+    end
 end
 
 macro aa_str(seq, flag)
@@ -51,5 +55,7 @@ macro aa_str(seq, flag)
 end
 
 macro aa_str(seq)
-    return LongAA(remove_newlines(seq))
+    return quote
+        LongAA($(remove_newlines(seq)))
+    end
 end


### PR DESCRIPTION
Currently, as documented in the documentation on "construction", string literals return a statically allocated `LongSequence`. This is great for performance, but can lead to unexpected bugs:

```julia
julia> using BioSequences

julia> start_codon() = dna"TAG"
start_codon (generic function with 1 method)

julia> push!(start_codon(), DNA_G)
4nt DNA Sequence:
TAGG

julia> push!(start_codon(), DNA_G)
5nt DNA Sequence:
TAGGG

julia> push!(start_codon(), DNA_G)
6nt DNA Sequence:
TAGGGG
```

This PR makes it allocate a new sequence at every call. To get the old behaviour back, one can use the "static" flag: `dna"TAG"s`. In other words, the old behaviour was fast by default, opt-in safe, this PR makes it safe by default, opt-in fast.

I'm not 100% sure it's a good change, but like 80% sure. I'll leave the PR up for a week or two, and merge it if no-one has any complaints.