### PR TITLE
Fix documenter warnings about broken links

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -57,15 +57,15 @@ biological sequences such as `push!`, `pop!`, and `insert!`, which should be
 familiar to anyone used to editing arrays.
 
 ```@docs
-push!
-pop!
-pushfirst!
-popfirst!
-insert!
+push!(::BioSequences.BioSequence, ::Any)
+pop!(::BioSequences.BioSequence)
+pushfirst!(::BioSequences.BioSequence, ::Any)
+popfirst!(::BioSequences.BioSequence)
+insert!(::BioSequences.BioSequence, ::Integer, ::Any)
 deleteat!(::BioSequences.BioSequence, ::Integer)
-append!
-resize!
-empty!
+append!(::BioSequences.BioSequence, ::BioSequences.BioSequence)
+resize!(::BioSequences.LongSequence, ::Integer)
+empty!(::BioSequences.BioSequence)
 ```
 
 Here are some examples:


### PR DESCRIPTION
Before, some of the automatic doc links referred to Base _functions_, instead of BioSequences _methods_. For example:
```@docs
push!
```
This caused errors, because Base functions like `push!` may link to other Base functions, which Documenter then cannot find.

Before merging this, I'd just need to see if the docs deploy properly with these changes.