### PR TITLE
Add workflow for downstream tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,0 +1,66 @@
+name: Downstream
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
+    runs-on: ${{ matrix.os }}
+    env:
+      GROUP: ${{ matrix.package.group }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: [1]
+        os: [ubuntu-latest]
+        package:
+          - {user: bioinfologics, repo: Pseudoseq.jl, group: BioSequences}
+          - {user: BioJulia, repo: BioAlignments.jl, group: BioSequences}
+          - {user: BioJulia, repo: BioStructures.jl, group: BioSequences}
+          - {user: BioJulia, repo: FASTX.jl, group: BioSequences}
+          - {user: BioJulia, repo: GenomeGraphs.jl, group: BioSequences}
+          - {user: BioJulia, repo: GenomicAnnotations.jl, group: BioSequences}
+          - {user: BioJulia, repo: GFF3.jl, group: BioSequences}
+          - {user: BioJulia, repo: KmerAnalysis.jl, group: BioSequences}
+          - {user: BioJulia, repo: ReadDatastores.jl, group: BioSequences}
+          - {user: BioJulia, repo: TwoBit.jl, group: BioSequences}
+          - {user: BioJulia, repo: XAM.jl, group: BioSequences}
+          - {user: crsl4, repo: PhyloNetworks.jl, group: BioSequences}
+          - {user: JuliaHealth, repo: CAOS.jl, group: BioSequences}
+          - {user: kool7d, repo: BioMakie.jl, group: BioSequences}
+          - {user: nguyetdang, repo: BioGraph.jl, group: BioSequences}
+          - {user: vanOosterhoutLab, repo: SpeedDate.jl, group: BioSequences}
+          - {user: varnerlab, repo: JUGRNModelGenerator.jl, group: BioSequences}
+          - {user: varnerlab, repo: VLConstraintBasedModelGenerationUtilities.jl, group: BioSequences}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone Downstream
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          path: downstream
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine.
+            # It means we marked this as a breaking change, so we don't need to worry about.
+            # Mistakenly introducing a breaking change, as we have intentionally made one.
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end


### PR DESCRIPTION
This PR adds a GitHub workflow to test active direct dependents of BioSequences. The workflow is modelled on https://github.com/FluxML/Zygote.jl/blob/master/.github/workflows/Downstream.yml.
The value for the group parameter in the package matrix is set as `BioSequences`. See https://github.com/FluxML/Flux.jl/pull/1555#discussion_r687992977 for an example of the group parameter in use. Setting the parameter as `BioSequences` will give direct dependents a free opportunity to provide a reduced test set without the need to come back and change anything here. 

Example output: https://github.com/CiaranOMara/BioSequences.jl/actions/runs/1358606131