### PR TITLE
Add parsing of BioSequence, simplify some printing

### DIFF
--- a/src/biosequence/conversion.jl
+++ b/src/biosequence/conversion.jl
@@ -27,6 +27,7 @@ function Base.convert(::Type{String}, seq::BioSequence, ::AsciiAlphabet)
     return str
 end
 
+Base.parse(::Type{S}, str::AbstractString) where {S<:BioSequence} = S(str)
 Base.String(seq::BioSequence) = convert(String, seq)
 Base.convert(::Type{Vector{DNA}}, seq::BioSequence{<:DNAAlphabet}) = collect(seq)
 Base.convert(::Type{Vector{RNA}}, seq::BioSequence{<:RNAAlphabet}) = collect(seq)

--- a/src/biosequence/printing.jl
+++ b/src/biosequence/printing.jl
@@ -122,9 +122,7 @@ function showcompact(io::IO, seq::BioSequence)
                 print(io, seq[i])
             end
         else
-            for x in seq
-                print(io, convert(Char, x))
-            end
+            print(io, seq)
         end
     end
 end
@@ -134,5 +132,3 @@ function string_compact(seq::BioSequence)
     showcompact(buf, seq)
     return String(take!(buf))
 end
-
-Base.parse(::Type{S}, str::AbstractString) where {S<:BioSequence} = convert(S, str)


### PR DESCRIPTION
Make `parse(::BioSequence, ::String)` work, and simplify some printing code. Very simple PR