### PR TITLE
Remove sequence conversion to/from String and Vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `LongRNASeq` -> `LongRNA` and `LongDNASeq` -> `LongDNA`
 - The interface for `Alphabet` and `BioSequence` is now more clearly defined, documented, and tested.
 - The constructor `LongSequence{A}(::Integer)` has been removed in favor of `LongSequence{A}(undef, ::Integer)`.
+- Biological sequences can no longer be converted to/from strings and vectors.
 
 ## [2.0.1]
 ### Changed

--- a/docs/src/construction.md
+++ b/docs/src/construction.md
@@ -112,34 +112,23 @@ true
 
 ## Conversion of sequence types
 
-You can convert between sequence types.
+You can convert between sequence types, if the sequences are compatible - that is, if the source sequence does not contain symbols that are un-encodable by the destination type.
 ```jldoctest
-julia> dna = dna"TTANGTAGACCG"
+julia> dna = dna"TTACGTAGACCG"
 12nt DNA Sequence:
-TTANGTAGACCG
+TTACGTAGACCG
 
-julia> rna = convert(LongRNA{4}, dna)
-12nt RNA Sequence:
-UUANGUAGACCG
-
+julia> dna2 = convert(LongDNA{2}, dna)
+12nt DNA Sequence:
+TTACGTAGACCG
 ```
 
-Sequences can be converted explicitly and implicitly, into arrays and strings:
-
+DNA/RNA are special in that they can be converted to each other, despite containing distinct symbols.
+When doing so, `DNA_T` is converted to `RNA_U` and vice versa.
 ```jldoctest
-julia> dna = dna"TTANGTAGACCG"
-12nt DNA Sequence:
-TTANGTAGACCG
-
-julia> dnastr = convert(String, dna)
-"TTANGTAGACCG"
-
-julia> # Implicit conversion to string - putting dna sequence in String vector 
-
-julia> arr = String[dna]
-1-element Vector{String}:
- "TTANGTAGACCG"
- 
+julia> convert(LongRNA{2}, dna"TAGCTAGG")
+8nt RNA Sequence:
+UAGCUAGG
 ```
 
 ## String literals

--- a/src/biosequence/conversion.jl
+++ b/src/biosequence/conversion.jl
@@ -7,28 +7,15 @@
 ### This file is a part of BioJulia.
 ### License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
-function Base.convert(::Type{S}, seq::BioSequence) where {S<:AbstractString}
-    return convert(S, seq, codetype(Alphabet(seq)))
+function (::Type{S})(seq::BioSequence) where {S <: AbstractString}
+    _string(S, seq, codetype(Alphabet(seq)))
 end
 
-@inline function Base.convert(::Type{S}, seq::BioSequence, ::AlphabetCode) where {S<:AbstractString}
+function _string(::Type{S}, seq::BioSequence, ::AlphabetCode) where {S<:AbstractString}
     return S([Char(x) for x in seq])
 end
 
-function Base.convert(::Type{String}, seq::BioSequence, ::AsciiAlphabet)
-    len = length(seq)
-    str = Base._string_n(len)
-    GC.@preserve str begin
-        p = pointer(str)
-        @inbounds for i in 1:len
-            unsafe_store!(p, stringbyte(seq[i]), i)
-        end
-    end
-    return str
+function _string(::Type{String}, seq::BioSequence, ::AsciiAlphabet)
+    String([stringbyte(s) for s in seq])
 end
 
-Base.String(seq::BioSequence) = convert(String, seq)
-Base.convert(::Type{Vector{DNA}}, seq::BioSequence{<:DNAAlphabet}) = collect(seq)
-Base.convert(::Type{Vector{RNA}}, seq::BioSequence{<:RNAAlphabet}) = collect(seq)
-Base.convert(::Type{Vector}, seq::BioSequence) = collect(seq)
-Base.convert(::Type{Vector{AminoAcid}}, seq::AASeq) = collect(seq)

--- a/src/longsequences/conversion.jl
+++ b/src/longsequences/conversion.jl
@@ -27,9 +27,4 @@ function Base.convert(::Type{T}, seq::LongSequence{<:NucleicAcidAlphabet}) where
     return T(seq)
 end
 
-# Convert from a LongSequence to to a DNA or RNA vector
-function Base.convert(::Type{LongSequence{A}}, seq::Vector) where A<:Alphabet
-    return LongSequence{A}(seq)
-end
-
 Base.parse(::Type{LongSequence{A}}, seq::AbstractString) where A = LongSequence{A}(seq)

--- a/test/biosequences/misc.jl
+++ b/test/biosequences/misc.jl
@@ -1,18 +1,10 @@
 @testset "Convert to String or Vector" begin
     seq = SimpleSeq("ACGUAAUUUCA")
 
-    @test convert(String, seq) == "ACGUAAUUUCA"
-    @test String(seq) == convert(String, seq)
-    @test convert(Vector, seq) == map(collect(convert(String, seq))) do char
-        convert(RNA, char)
-    end
-    @test convert(Vector, seq) == convert(Vector{RNA}, seq)
+    @test String(seq) == "ACGUAAUUUCA"
 
     seq = SimpleSeq(RNA[])
-    @test String(seq) == convert(String, seq)
-    @test convert(String, seq) == ""
-    @test convert(Vector, seq) == RNA[]
-    @test convert(Vector{RNA}, seq) == RNA[]
+    @test isempty(seq)
 end
 
 @testset "Counting" begin

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -179,7 +179,7 @@ end
         end
         str = string([chunk[parts[i]] for (i, chunk) in enumerate(chunks)]...)
         seq = *([LongSequence{A}(chunk)[parts[i]] for (i, chunk) in enumerate(chunks)]...)
-        @test convert(String, seq) == uppercase(str)
+        @test String(seq) == uppercase(str)
     end
 
     for _ in [1, 2, 5, 10, 18, 32, 55, 64, 70]
@@ -209,7 +209,7 @@ end
         n = rand(1:10)
         str = chunk[start:stop] ^ n
         seq = LongSequence{A}(chunk)[start:stop] ^ n
-        @test convert(String, seq) == uppercase(str)
+        @test String(seq) == uppercase(str)
     end
 
     for _ in 1:10

--- a/test/longsequences/conversion.jl
+++ b/test/longsequences/conversion.jl
@@ -22,7 +22,7 @@ end
     # Check that sequences in strings survive round trip conversion:
     #   String → LongSequence → String
     function test_string_construction(A::Type, seq::AbstractString)
-        @test convert(String, LongSequence{A}(seq)) == uppercase(seq)
+        @test String(LongSequence{A}(seq)) == uppercase(seq)
     end
 
     function test_string_parse(A::Type, seq::AbstractString)

--- a/test/longsequences/transformations.jl
+++ b/test/longsequences/transformations.jl
@@ -1,29 +1,29 @@
 @testset "Transformations" begin
     function test_reverse(A, seq)
         revseq = reverse(LongSequence{A}(seq))
-        @test convert(String, revseq) == reverse(seq)
+        @test String(revseq) == reverse(seq)
         revseq = reverse!(LongSequence{A}(seq))
-        @test convert(String, revseq) == reverse(seq)
+        @test String(revseq) == reverse(seq)
     end
 
     function test_dna_complement(A, seq)
         comp = complement(LongSequence{A}(seq))
-        @test convert(String, comp) == dna_complement(seq)
+        @test String(comp) == dna_complement(seq)
     end
 
     function test_rna_complement(A, seq)
         comp = complement(LongSequence{A}(seq))
-        @test convert(String, comp) == rna_complement(seq)
+        @test String(comp) == rna_complement(seq)
     end
 
     function test_dna_revcomp(A, seq)
         revcomp = reverse_complement(LongSequence{A}(seq))
-        @test convert(String, revcomp) == reverse(dna_complement(seq))
+        @test String(revcomp) == reverse(dna_complement(seq))
     end
 
     function test_rna_revcomp(A, seq)
         revcomp = reverse_complement(LongSequence{A}(seq))
-        @test convert(String, revcomp) == reverse(rna_complement(seq))
+        @test String(revcomp) == reverse(rna_complement(seq))
     end
 
     @testset "Reverse" begin


### PR DESCRIPTION
# Remove the ability to convert BioSequence to/rom String and Vector

This is a speculative, breaking change for v3. I'm pretty sure it's the right way to go, but it needs discussion.
Currently, we allow conversion between `BioSequence` and `String` and between `BioSequence` and `Vector`. I think having constructors between these are reasonable, but not conversion.

What's the difference between conversion and construction anyway? The Base docs on this issue states:

> since convert can be called implicitly, its methods are restricted to cases that are considered "safe" or "unsurprising". convert will only convert between types that represent the same basic kind of thing (e.g. different representations of numbers, or different string encodings).

But what exactly is "safe" and "unsurprising" is in the eye of the beholder.
To me, it makes sense to `convert` between values that are considered equal. For example, `2.0` can be converted to `0x02` because `2.0 == 0x02`.

However, since
```julia
julia> [DNA_A, DNA_G] == dna"AG"
false

julia> "AG" == dna"AG"
false
```

I think we should not be allowing conversion here.

Furthermore, `convert` is called implicitly. This is often acceptable for small bitstypes like integers where performance is not a concern. But implicitly constructing long strings on the heap is not great. Especially because the implications of implicitly creating copies of mutable structs are complicated.

## :ballot_box_with_check: Checklist

- [X] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [X] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [X] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [X] :ok: There are unit tests that cover the code changes I have made.
- [X] :ok: The unit tests cover my code changes AND they pass.
- [X] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [X] :ok: All changes should be compatible with the latest stable version of Julia.
- [X] :thought_balloon: I have commented liberally for any complex pieces of internal code.
