### PR TITLE
Add `has_interface` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,17 +9,17 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Twiddle = "7200193e-83a8-5a55-b20d-5d36d44a0795"
 
 [compat]
-BioSymbols = "5.0.0"
+BioSymbols = "5.1.0"
 StableRNGs = "0.1, 1.0"
 Twiddle = "1.1.1"
 julia = "1"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
-StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 
 [targets]
 test = ["Test", "StatsBase", "YAML", "LinearAlgebra", "StableRNGs"]

--- a/src/biosequence/printing.jl
+++ b/src/biosequence/printing.jl
@@ -54,17 +54,16 @@ end
 
 # Generic method. The different name allows subtypes of BioSequence to
 # selectively call the generic print despite being more specific type
-function _print(buffer::SimpleBuffer, seq::BioSequence, width::Integer, ::UnicodeAlphabet)
+function _print(io::IO, seq::BioSequence, width::Integer, ::UnicodeAlphabet)
     col = 0
     for x in seq
         col += 1
         if (width > 0) & (col > width)
-            write(buffer, '\n')
+            write(io, '\n')
             col = 1
         end
-        print(buffer, x)
+        print(io, x)
     end
-    close(buffer)
     return nothing
 end
 

--- a/test/biosequences/biosequence.jl
+++ b/test/biosequences/biosequence.jl
@@ -19,6 +19,8 @@ Base.resize!(x::SimpleSeq, len::Int) = (resize!(x.x, len); x)
 random_simple(len::Integer) = SimpleSeq(rand([RNA_A, RNA_C, RNA_G, RNA_U], len))
 
 @testset "Basics" begin
+    @test BioSequences.has_interface(BioSequence, SimpleSeq, [RNA_C], true)
+
     seq = SimpleSeq([RNA_C, RNA_G, RNA_U])
     
     @test seq isa BioSequence{RNAAlphabet{2}}

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -1,4 +1,10 @@
 @testset "Basics" begin
+    @test BioSequences.has_interface(BioSequence, LongDNA{2}, [DNA_G], true)
+    @test BioSequences.has_interface(BioSequence, LongDNA{4}, [DNA_G], true)
+    @test BioSequences.has_interface(BioSequence, LongRNA{2}, [RNA_G], true)
+    @test BioSequences.has_interface(BioSequence, LongRNA{4}, [RNA_G], true)
+    @test BioSequences.has_interface(BioSequence, LongAA, [AA_G], true)
+
 	seq = LongSequence{DNAAlphabet{2}}()
 	@test isempty(seq)
 
@@ -326,4 +332,26 @@ end
         """
         @test a == b
     end
+end
+
+@testset "Custom ASCII alphabet" begin
+    @test string(LongSequence{ReducedAAAlphabet}("FSPMKH")) == "FSPMKH"
+    buf = IOBuffer()
+    print(buf, LongSequence{ReducedAAAlphabet}("AGTDNWLE"))
+    @test String(take!(buf)) == "AGTDNWLE"
+
+    #### Now add AsciiAlphabet capacity
+    BioSequences.codetype(::ReducedAAAlphabet) = BioSequences.AsciiAlphabet()
+    function BioSequences.ascii_encode(::ReducedAAAlphabet, x::UInt8)
+        for sym in symbols(ReducedAAAlphabet())
+            if UInt8(Char(sym)) == x
+                return UInt8(encode(ReducedAAAlphabet(), sym))
+            end
+        end
+    end
+
+    @test string(LongSequence{ReducedAAAlphabet}("FSPMKH")) == "FSPMKH"
+    buf = IOBuffer()
+    print(buf, LongSequence{ReducedAAAlphabet}("AGTDNWLE"))
+    @test String(take!(buf)) == "AGTDNWLE"
 end


### PR DESCRIPTION
As suggested by @BenJWard in #140.

This adds a non-exported function `has_interface(::Type{T}, x::T, args...)`, which tests if `x` conforms to the `T` interface.
It also adds more tests.
The additional `args` depend on the interface in quesiton, in case more objects are needed to tell if the interface is followed.

Because I also test the `stringbyte` interface, this is built on #200.