### PR TITLE
WIP: Test bonanza for v3

### DIFF
--- a/docs/src/construction.md
+++ b/docs/src/construction.md
@@ -306,3 +306,16 @@ So the take home message of sequence literals is this:
 Be careful when you are using sequence literals inside of functions, and inside
 the bodies of things like for loops. And if you use them and are unsure, use the
  's' and 'd' flags to ensure the behaviour you get is the behaviour you intend.
+
+## Comparison to other sequence types
+Following Base standards, BioSequences do not compare equal to other containers even if they have the same elements.
+To e.g. compare a BioSequence with a vector of DNA, compare the elements themselves:
+```jldoctest
+julia> seq = dna"GAGCTGA"; vec = collect(seq);
+
+julia> seq == vec, isequal(seq, vec)
+(false, false)
+
+julia> length(seq) == length(vec) && all(i == j for (i, j) in zip(seq, vec))
+true 
+```

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -126,6 +126,7 @@ export
     reverse_complement!,
     ungap,
     ungap!,
+    join!,
     
     ###
     ### LongSequence

--- a/src/biosequence/biosequence.jl
+++ b/src/biosequence/biosequence.jl
@@ -63,7 +63,7 @@ end
 
 # Fast path for iterables we know are stateless
 function join!(seq::BioSequence, it::Union{Vector, Tuple, Set})
-    _join(resize!(seq, sum(length, it)), it, Val(true))
+    _join!(resize!(seq, sum(length, it)), it, Val(true))
 end
 
 join!(seq::BioSequence, it) = _join!(seq, it, Val(false))

--- a/src/biosequence/copying.jl
+++ b/src/biosequence/copying.jl
@@ -32,7 +32,7 @@ julia> copyto!(seq, 2, rna"UUUU", 1, 4)
 TTTTTM
 ```
 """
-function _copyto!(dst::BioSequence{A}, doff::Integer,
+function Base.copyto!(dst::BioSequence{A}, doff::Integer,
     src::BioSequence, soff::Integer,
     N::Integer) where {A <: Alphabet}
 

--- a/src/biosequence/indexing.jl
+++ b/src/biosequence/indexing.jl
@@ -101,9 +101,6 @@ Base.@propagate_inbounds function Base.setindex!(seq::BioSequence, x, locs::Abst
     return seq
 end
 
-# For backwards compatibility
-unsafe_setindex!(seq::BioSequence, x, i) = @inbounds seq[i] = x
-
 function Base.setindex!(seq::BioSequence, x, ::Colon)
     return setindex!(seq, x, 1:lastindex(seq))
 end

--- a/src/biosequence/transformations.jl
+++ b/src/biosequence/transformations.jl
@@ -235,7 +235,7 @@ end
 Create the canonical sequence of `seq`.
 
 """
-canonical(seq::NucleotideSeq) = is_canonical(seq) ? copy(seq) : reverse_complement(seq)
+canonical(seq::NucleotideSeq) = iscanonical(seq) ? copy(seq) : reverse_complement(seq)
 
 "Create a copy of a sequence with gap characters removed."
 ungap(seq::BioSequence)  =  filter(!isgap, seq)

--- a/src/bit-manipulation/bitindex.jl
+++ b/src/bit-manipulation/bitindex.jl
@@ -48,7 +48,6 @@ Base.:-(i::BitIndex{N,W}, n::Integer) where {N,W} = BitIndex{N,W}(i.val - n)
 Base.:-(i1::BitIndex, i2::BitIndex) = i1.val - i2.val
 Base.:(==)(i1::BitIndex, i2::BitIndex) = i1.val == i2.val
 Base.isless(i1::BitIndex, i2::BitIndex) = isless(i1.val, i2.val)
-Base.cmp(i1::BitIndex, i2::BitIndex) = cmp(i1.val, i2.val)
 
 @inline function nextposition(i::BitIndex{N,W}) where {N,W}
     return i + N
@@ -76,13 +75,6 @@ Base.show(io::IO, i::BitIndex) = print(io, '(', index(i), ", ", offset(i), ')')
     return chunk & bitmask(bidx)
 end
 
-"Extract the element stored in a packed bitarray referred to by bidx."
-@inline function extract_encoded_element(bidx::BitIndex{N,W}, data::NTuple{n,W}) where {N,n,W}
-    @inbounds chunk = data[index(bidx)]
-    offchunk = chunk >> (bitwidth(bidx) - N - offset(bidx))
-    return offchunk & bitmask(bidx)
-end
-
 # Create a bit mask that fills least significant `n` bits (`n` must be a
 # non-negative integer).
 "Create a bit mask covering the least significant `n` bits."
@@ -95,4 +87,3 @@ end
 # This is used in the extract_encoded_element function.
 bitmask(::BitIndex{N,W}) where {N, W} = bitmask(W, N)
 bitmask(n::Integer) = bitmask(UInt64, n)
-bitmask(::Type{T}, ::Val{N}) where {T, N} = (one(T) << N) - one(T)

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -63,16 +63,15 @@ end
 
 function LongSequence{A}(
     src::Union{AbstractString,AbstractVector{UInt8}},
-    part::UnitRange{<:Integer}=1:length(src)
+    part::AbstractUnitRange{<:Integer}=1:length(src)
 ) where {A<:Alphabet}
     len = length(part)
     seq = LongSequence{A}(undef, len)
     return copyto!(seq, 1, src, first(part), len)
 end
 
-
 # create a subsequence
-function LongSequence(other::LongSequence, part::UnitRange{<:Integer})
+function LongSequence(other::LongSequence, part::AbstractUnitRange{<:Integer})
     checkbounds(other, part)
     subseq = typeof(other)(undef, length(part))
     copyto!(subseq, 1, other, first(part), length(part))

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -22,7 +22,6 @@ function LongSequence{A}(::UndefInitializer, len::Integer) where {A<:Alphabet}
 end
 
 # Generic constructor
-LongSequence(it) = LongSequence{eltype(it)}(it)
 function LongSequence{A}(it) where {A <: Alphabet}
     len = length(it)
     data = Vector{UInt64}(undef, seq_data_len(A, len))
@@ -63,13 +62,14 @@ function LongSequence{A}(s::Union{String, SubString{String}}, ::AsciiAlphabet) w
 end
 
 function LongSequence{A}(
-        src::Union{AbstractString,AbstractVector{UInt8}},
-        startpos::Integer=1,
-        stoppos::Integer=length(src)) where {A<:Alphabet}
-    len = stoppos - startpos + 1
+    src::Union{AbstractString,AbstractVector{UInt8}},
+    part::UnitRange{<:Integer}=1:length(src)
+) where {A<:Alphabet}
+    len = length(part)
     seq = LongSequence{A}(undef, len)
-    return copyto!(seq, 1, src, startpos, len)
+    return copyto!(seq, 1, src, first(part), len)
 end
+
 
 # create a subsequence
 function LongSequence(other::LongSequence, part::UnitRange{<:Integer})

--- a/src/longsequences/indexing.jl
+++ b/src/longsequences/indexing.jl
@@ -10,21 +10,12 @@
     bitindex(N, encoded_data_eltype(typeof(x)), i)
 end
 
-@inline function bitindex(x::LongSubSeq, i::Integer)
-    N = BitsPerSymbol(Alphabet(typeof(x)))
-    bitindex(N, encoded_data_eltype(typeof(x)), i % UInt + first(x.part) - 1)
-end
-
 firstbitindex(s::SeqOrView) = bitindex(s, firstindex(s))
 lastbitindex(s::SeqOrView) = bitindex(s, lastindex(s))
 
 @inline function extract_encoded_element(x::SeqOrView, i::Integer)
     bi = bitindex(x, i % UInt)
     extract_encoded_element(bi, x.data)
-end
-
-@inline function encoded_setindex!(seq::SeqOrView, bin::Unsigned, i::Integer)
-    encoded_setindex!(seq, UInt64(bin), bitindex(seq, i))
 end
 
 @inline function encoded_setindex!(s::SeqOrView, v::UInt64, i::BitIndex)
@@ -43,9 +34,11 @@ function Base.getindex(seq::LongSequence, part::UnitRange{<:Integer})
 end
 
 # More efficient due to copyto!
-function Base.setindex!(seq::SeqOrView{A},
-                        other::SeqOrView{A},
-                        locs::UnitRange{<:Integer}) where {A <: Alphabet}
+function Base.setindex!(
+    seq::SeqOrView{A},
+    other::SeqOrView{A},
+    locs::UnitRange{<:Integer}
+) where {A <: Alphabet}
     @boundscheck checkbounds(seq, locs)
     @boundscheck if length(other) != length(locs)
         throw(DimensionMismatch("Attempt to assign $(length(locs)) values to $(length(seq)) destinations"))
@@ -53,8 +46,11 @@ function Base.setindex!(seq::SeqOrView{A},
     return copyto!(seq, locs.start, other, 1, length(locs))
 end
 
-@inline function encoded_setindex!(seq::SeqOrView{A},
-				   bin::Unsigned, i::Integer) where {A <: Alphabet}
+@inline function encoded_setindex!(
+    seq::SeqOrView{A},
+	bin::Unsigned, 
+    i::Integer
+) where {A <: Alphabet}
 	return encoded_setindex!(seq, bin, bitindex(seq, i))
 end
 

--- a/src/longsequences/indexing.jl
+++ b/src/longsequences/indexing.jl
@@ -27,7 +27,7 @@ end
 end
 
 # More efficient due to copyto!
-function Base.getindex(seq::LongSequence, part::UnitRange{<:Integer})
+function Base.getindex(seq::LongSequence, part::AbstractUnitRange{<:Integer})
 	@boundscheck checkbounds(seq, part)
 	newseq = typeof(seq)(undef, length(part))
 	return copyto!(newseq, 1, seq, first(part), length(part))
@@ -37,7 +37,7 @@ end
 function Base.setindex!(
     seq::SeqOrView{A},
     other::SeqOrView{A},
-    locs::UnitRange{<:Integer}
+    locs::AbstractUnitRange{<:Integer}
 ) where {A <: Alphabet}
     @boundscheck checkbounds(seq, locs)
     @boundscheck if length(other) != length(locs)
@@ -48,7 +48,7 @@ end
 
 @inline function encoded_setindex!(
     seq::SeqOrView{A},
-	bin::Unsigned, 
+    bin::Unsigned, 
     i::Integer
 ) where {A <: Alphabet}
 	return encoded_setindex!(seq, bin, bitindex(seq, i))

--- a/src/longsequences/seqview.jl
+++ b/src/longsequences/seqview.jl
@@ -35,8 +35,9 @@ Base.copy(v::LongSubSeq{A}) where A = LongSequence{A}(v)
  
 encoded_data_eltype(::Type{<:LongSubSeq}) = encoded_data_eltype(LongSequence)
 
-@inline function bitindex(x::LongSubSeq{A}, i::Integer) where A
-	bitindex(BitsPerSymbol(A), encoded_data_eltype(typeof(x)), i - first(x.part) + 1)
+@inline function bitindex(x::LongSubSeq, i::Integer)
+    N = BitsPerSymbol(Alphabet(typeof(x)))
+    bitindex(N, encoded_data_eltype(typeof(x)), i % UInt + first(x.part) - 1)
 end
 
 # Constructors
@@ -48,12 +49,12 @@ function LongSubSeq{A}(seq::LongSubSeq{A}) where A
     return LongSubSeq{A}(seq.data, seq.part)
 end
 
-function LongSubSeq{A}(seq::LongSequence{A}, part::UnitRange{<:Integer}) where A
+function LongSubSeq{A}(seq::LongSequence{A}, part::AbstractUnitRange{<:Integer}) where A
     @boundscheck checkbounds(seq, part)
-    return LongSubSeq{A}(seq.data, part)
+    return LongSubSeq{A}(seq.data, UnitRange{Int}(part))
 end
 
-function LongSubSeq{A}(seq::LongSubSeq{A}, part::UnitRange{<:Integer}) where A
+function LongSubSeq{A}(seq::LongSubSeq{A}, part::AbstractUnitRange{<:Integer}) where A
     @boundscheck checkbounds(seq, part)
     newpart = first(part) + first(seq.part) - 1 : last(part) + first(seq.part) - 1
     return LongSubSeq{A}(seq.data, newpart)
@@ -66,7 +67,7 @@ end
 LongSubSeq(seq::SeqOrView, ::Colon) = LongSubSeq(seq, 1:lastindex(seq))
 LongSubSeq(seq::BioSequence{A}) where A = LongSubSeq{A}(seq)
 
-Base.view(seq::SeqOrView, part::UnitRange) = LongSubSeq(seq, part)
+Base.view(seq::SeqOrView, part::AbstractUnitRange) = LongSubSeq(seq, part)
 
 # Conversion
 function LongSequence(s::LongSubSeq{A}) where A
@@ -95,6 +96,6 @@ function Base.convert(::Type{T1}, seq::T2) where
 end
 
 # Indexing
-function Base.getindex(seq::LongSubSeq, part::UnitRange{<:Integer})
+function Base.getindex(seq::LongSubSeq, part::AbstractUnitRange{<:Integer})
 	return LongSubSeq(seq, part)
 end

--- a/src/longsequences/seqview.jl
+++ b/src/longsequences/seqview.jl
@@ -34,6 +34,7 @@ Base.length(v::LongSubSeq) = last(v.part) - first(v.part) + 1
 Base.copy(v::LongSubSeq{A}) where A = LongSequence{A}(v)
  
 encoded_data_eltype(::Type{<:LongSubSeq}) = encoded_data_eltype(LongSequence)
+symbols_per_data_element(x::LongSubSeq) = div(64, bits_per_symbol(Alphabet(x)))
 
 @inline function bitindex(x::LongSubSeq, i::Integer)
     N = BitsPerSymbol(Alphabet(typeof(x)))

--- a/test/alphabet.jl
+++ b/test/alphabet.jl
@@ -36,6 +36,14 @@
     end
 end
 
+@testset "Basic" begin
+    @test length(DNAAlphabet{4}()) == 16
+    @test length(RNAAlphabet{2}()) == 4
+    @test length(AminoAcidAlphabet()) == 28
+
+    @test BioSequences.symbols(RNAAlphabet{2}()) == (RNA_A, RNA_C, RNA_G, RNA_U)
+end
+
 encode = BioSequences.encode
 EncodeError = BioSequences.EncodeError
 decode = BioSequences.decode

--- a/test/alphabet.jl
+++ b/test/alphabet.jl
@@ -91,6 +91,10 @@ struct ReducedAAAlphabet <: Alphabet end
         @test encode(ReducedAAAlphabet(), aa) === data
         @test decode(ReducedAAAlphabet(), data) === aa
     end
+
+    str = "NSTPHML"
+    @test String(LongSequence{ReducedAAAlphabet}(str)) == str
+
     @test_throws EncodeError encode(ReducedAAAlphabet(), AA_V)
     @test_throws EncodeError encode(ReducedAAAlphabet(), AA_I)
     @test_throws EncodeError encode(ReducedAAAlphabet(), AA_R)

--- a/test/biosequences/biosequence.jl
+++ b/test/biosequences/biosequence.jl
@@ -51,6 +51,12 @@ random_simple(len::Integer) = SimpleSeq(rand([RNA_A, RNA_C, RNA_G, RNA_U], len))
     @test join!(SimpleSeq([]), gen) == SimpleSeq([RNA(i) for i in "CGUUCU"])
     @test join(SimpleSeq, [seq, seq2]) == join!(SimpleSeq([]), [seq, seq2])
     @test join(SimpleSeq, gen) == join!(SimpleSeq([]), gen)
+
+    @test copy!(SimpleSeq([]), seq) == seq
+    seq3 = copy(seq2)
+    @test copyto!(seq3, seq) == seq
+    seq3 = copy(seq2)
+    @test copyto!(seq3, 2, seq, 3, 1) == SimpleSeq([RNA(i) for i in "UUU"])
     
     @test_throws EncodeError SimpleSeq([RNA_C, RNA_G, RNA_M])
     @test_throws EncodeError SimpleSeq([RNA_Gap])

--- a/test/biosequences/biosequence.jl
+++ b/test/biosequences/biosequence.jl
@@ -45,6 +45,13 @@ random_simple(len::Integer) = SimpleSeq(rand([RNA_A, RNA_C, RNA_G, RNA_U], len))
     @test prevind(seq, lastindex(seq)) == 2
     @test prevind(seq, 2) == 1
 
+    seq2 = SimpleSeq([RNA_U, RNA_C, RNA_U])
+    gen = (i for i in [seq, seq2])
+    @test join!(SimpleSeq([]), [seq, seq2]) == SimpleSeq([RNA(i) for i in "CGUUCU"])
+    @test join!(SimpleSeq([]), gen) == SimpleSeq([RNA(i) for i in "CGUUCU"])
+    @test join(SimpleSeq, [seq, seq2]) == join!(SimpleSeq([]), [seq, seq2])
+    @test join(SimpleSeq, gen) == join!(SimpleSeq([]), gen)
+    
     @test_throws EncodeError SimpleSeq([RNA_C, RNA_G, RNA_M])
     @test_throws EncodeError SimpleSeq([RNA_Gap])
     @test_throws MethodError SimpleSeq(1:3)

--- a/test/biosequences/indexing.jl
+++ b/test/biosequences/indexing.jl
@@ -173,3 +173,12 @@ end
         @test seq == SimpleSeq(map(RNA, collect("AACCGCAUCAGGAUCUG")))
     end
 end
+
+@testset "BitIndex" begin
+    ind = BioSequences.BitIndex{4, UInt64}(16)
+    BioSequences.BitsPerSymbol(ind) = BioSequences.BitsPerSymbol{4}()
+    BioSequences.bitwidth(UInt64) = 64
+    BioSequences.bitwidth(UInt16) = 16
+    BioSequences.prevposition(ind) == BioSequences.BitIndex{4, UInt64}(12)
+    BioSequences.nextposition(ind) == BioSequences.BitIndex{4, UInt64}(20)
+end

--- a/test/biosequences/misc.jl
+++ b/test/biosequences/misc.jl
@@ -192,3 +192,10 @@ end
     complement!(seq)
     @test seq == SimpleSeq([RNA(i) for i in "GAACUA"])
 end
+
+@testset "Ungap" begin
+    seq = SimpleSeq([RNA(i) for i in "UAGUUC"])
+    @test ungap(seq) == seq
+    cp = copy(seq)
+    @test ungap!(seq) == cp
+end

--- a/test/biosequences/misc.jl
+++ b/test/biosequences/misc.jl
@@ -128,6 +128,12 @@ end
     @test iscanonical(SimpleSeq("AAUU"))
     @test !iscanonical(SimpleSeq("UGGA"))
     @test !iscanonical(SimpleSeq("CGAU"))
+
+    @test canonical(SimpleSeq("UGGA")) == SimpleSeq("UCCA")
+    @test canonical(SimpleSeq("GCAC")) == SimpleSeq("GCAC")
+    seq = SimpleSeq("CGAU")
+    canonical!(seq)
+    @test seq == SimpleSeq("AUCG")
 end
 
 @testset "Ispalindromic" begin
@@ -160,4 +166,29 @@ end
     @test !hasambiguity(SimpleSeq(""))
     @test !hasambiguity(SimpleSeq("A"))
     @test !hasambiguity(SimpleSeq("ACGU"))
+end
+
+@testset "Shuffle" begin
+    function test_same(a, b)
+        @test all(symbols(Alphabet(a))) do i
+            count(isequal(i), a) == count(isequal(i), b)
+        end
+    end
+    seq = SimpleSeq([RNA(i) for i in "AGCGUUAUGCUGAUUAGGAC"])
+    seq2 = Random.shuffle(seq)
+    test_same(seq, seq2)
+    Random.shuffle!(seq)
+    test_same(seq, seq2)
+end
+
+@testset "Reverse-complement" begin
+    seq = SimpleSeq([RNA(i) for i in "UAGUUC"])
+    @test reverse(seq) == SimpleSeq([RNA(i) for i in "CUUGAU"])
+    @test complement(seq) == SimpleSeq([RNA(i) for i in "AUCAAG"])
+    @test reverse_complement(seq) == reverse(complement(seq))
+
+    reverse!(seq)
+    @test seq == SimpleSeq([RNA(i) for i in "CUUGAU"])
+    complement!(seq)
+    @test seq == SimpleSeq([RNA(i) for i in "GAACUA"])
 end

--- a/test/counting.jl
+++ b/test/counting.jl
@@ -28,7 +28,13 @@
         end
     end
     
-    function testcounter(pred::Function, alias::Function, seqa::BioSequence, seqb::BioSequence)
+    function testcounter(
+        pred::Function,
+        alias::Function,
+        seqa::BioSequence,
+        seqb::BioSequence,
+        singlearg::Bool
+    )
         # Test that order does not matter.
         @test count(pred, seqa, seqb) == count(pred, seqb, seqa)
         @test BioSequences.count_naive(pred, seqa, seqb) == BioSequences.count_naive(pred, seqb, seqa)
@@ -39,10 +45,21 @@
         # Test that the alias function works.
         @test count(pred, seqa, seqb) == alias(seqa, seqb)
         @test count(pred, seqb, seqa) == alias(seqb, seqa)
+        if singlearg
+            @test count(pred, seqa) == count(pred, (i for i in seqa))
+            @test BioSequences.count_naive(pred, seqa) == BioSequences.count(pred, seqa)
+        end
     end
     
-    function counter_random_tests(pred::Function, alias::Function, alphx::Type{<:Alphabet}, alphy::Type{<:Alphabet}, subset::Bool)
-        for _ in 1:20
+    function counter_random_tests(
+        pred::Function,
+        alias::Function,
+        alphx::Type{<:Alphabet},
+        alphy::Type{<:Alphabet},
+        subset::Bool,
+        singlearg::Bool
+    )
+        for _ in 1:10
             seqA = random_seq(alphx, rand(10:100))
             seqB = random_seq(alphy, rand(10:100))
             sa = seqA
@@ -55,7 +72,7 @@
                 sa = subA
                 sb = subB
             end
-            testcounter(pred, alias, sa, sb)
+            testcounter(pred, alias, sa, sb, singlearg)
         end
     end
     
@@ -63,10 +80,10 @@
         for a in (DNAAlphabet, RNAAlphabet)
             for sub in (true, false)
                 for n in (4, 2)
-                    counter_random_tests(!=, mismatches, a{n}, a{n}, sub)
+                    counter_random_tests(!=, mismatches, a{n}, a{n}, sub, false)
                 end
-                counter_random_tests(!=, mismatches, a{4}, a{2}, sub)
-                counter_random_tests(!=, mismatches, a{2}, a{4}, sub)
+                counter_random_tests(!=, mismatches, a{4}, a{2}, sub, false)
+                counter_random_tests(!=, mismatches, a{2}, a{4}, sub, false)
             end
         end
     end
@@ -75,10 +92,10 @@
         for a in (DNAAlphabet, RNAAlphabet)
             for sub in (true, false)
                 for n in (4, 2)
-                    counter_random_tests(==, matches, a{n}, a{n}, sub)
+                    counter_random_tests(==, matches, a{n}, a{n}, sub, false)
                 end
-                counter_random_tests(==, matches, a{4}, a{2}, sub)
-                counter_random_tests(==, matches, a{2}, a{4}, sub)
+                counter_random_tests(==, matches, a{4}, a{2}, sub, false)
+                counter_random_tests(==, matches, a{2}, a{4}, sub, false)
             end
         end
     end
@@ -87,23 +104,22 @@
         for a in (DNAAlphabet, RNAAlphabet)
             for sub in (true, false)
                 for n in (4, 2)
-                    counter_random_tests(isambiguous, n_ambiguous, a{n}, a{n}, sub)
+                    counter_random_tests(isambiguous, n_ambiguous, a{n}, a{n}, sub, true)
                 end
-                counter_random_tests(isambiguous, n_ambiguous, a{4}, a{2}, sub)
-                counter_random_tests(isambiguous, n_ambiguous, a{2}, a{4}, sub)
+                counter_random_tests(isambiguous, n_ambiguous, a{4}, a{2}, sub, true)
+                counter_random_tests(isambiguous, n_ambiguous, a{2}, a{4}, sub, true)
             end
         end
-        @test count(isambiguous, LongSequence{DNAAlphabet{2}}("TAG")) == 0 
     end
     
     @testset "Certain" begin
         for a in (DNAAlphabet, RNAAlphabet)
             for sub in (true, false)
                 for n in (4, 2)
-                    counter_random_tests(iscertain, n_certain, a{n}, a{n}, sub)
+                    counter_random_tests(iscertain, n_certain, a{n}, a{n}, sub, true)
                 end
-                counter_random_tests(iscertain, n_certain, a{4}, a{2}, sub)
-                counter_random_tests(iscertain, n_certain, a{2}, a{4}, sub)
+                counter_random_tests(iscertain, n_certain, a{4}, a{2}, sub, true)
+                counter_random_tests(iscertain, n_certain, a{2}, a{4}, sub, true)
             end
         end
     end
@@ -112,10 +128,10 @@
         for a in (DNAAlphabet, RNAAlphabet)
             for sub in (true, false)
                 for n in (4, 2)
-                    counter_random_tests(isgap, n_gaps, a{n}, a{n}, sub)
+                    counter_random_tests(isgap, n_gaps, a{n}, a{n}, sub, true)
                 end
-                counter_random_tests(isgap, n_gaps, a{4}, a{2}, sub)
-                counter_random_tests(isgap, n_gaps, a{2}, a{4}, sub)
+                counter_random_tests(isgap, n_gaps, a{4}, a{2}, sub, true)
+                counter_random_tests(isgap, n_gaps, a{2}, a{4}, sub, true)
             end
         end
     end

--- a/test/counting.jl
+++ b/test/counting.jl
@@ -67,8 +67,8 @@
             if subset
                 intA = random_interval(1, length(seqA))
                 intB = random_interval(1, length(seqB))
-                subA = seqA[intA]
-                subB = seqB[intB]
+                subA = view(seqA, intA)
+                subB = view(seqB, intB)
                 sa = subA
                 sb = subB
             end
@@ -78,13 +78,14 @@
     
     @testset "Mismatches" begin
         for a in (DNAAlphabet, RNAAlphabet)
+            # Can't promote views
             for sub in (true, false)
                 for n in (4, 2)
                     counter_random_tests(!=, mismatches, a{n}, a{n}, sub, false)
                 end
-                counter_random_tests(!=, mismatches, a{4}, a{2}, sub, false)
-                counter_random_tests(!=, mismatches, a{2}, a{4}, sub, false)
             end
+            counter_random_tests(!=, mismatches, a{4}, a{2}, false, false)
+            counter_random_tests(!=, mismatches, a{2}, a{4}, false, false)
         end
     end
     
@@ -94,45 +95,46 @@
                 for n in (4, 2)
                     counter_random_tests(==, matches, a{n}, a{n}, sub, false)
                 end
-                counter_random_tests(==, matches, a{4}, a{2}, sub, false)
-                counter_random_tests(==, matches, a{2}, a{4}, sub, false)
             end
+            counter_random_tests(==, matches, a{4}, a{2}, false, false)
+            counter_random_tests(==, matches, a{2}, a{4}, false, false)
         end
     end
     
     @testset "Ambiguous" begin
         for a in (DNAAlphabet, RNAAlphabet)
-            for sub in (true, false)
-                for n in (4, 2)
+            # Can't promote views
+            for n in (4, 2)
+                for sub in (true, false)
                     counter_random_tests(isambiguous, n_ambiguous, a{n}, a{n}, sub, true)
                 end
-                counter_random_tests(isambiguous, n_ambiguous, a{4}, a{2}, sub, true)
-                counter_random_tests(isambiguous, n_ambiguous, a{2}, a{4}, sub, true)
             end
+            counter_random_tests(isambiguous, n_ambiguous, a{4}, a{2}, false, true)
+            counter_random_tests(isambiguous, n_ambiguous, a{2}, a{4}, false, true)
         end
     end
     
     @testset "Certain" begin
         for a in (DNAAlphabet, RNAAlphabet)
-            for sub in (true, false)
-                for n in (4, 2)
+            for n in (4, 2)
+                for sub in (true, false)
                     counter_random_tests(iscertain, n_certain, a{n}, a{n}, sub, true)
                 end
-                counter_random_tests(iscertain, n_certain, a{4}, a{2}, sub, true)
-                counter_random_tests(iscertain, n_certain, a{2}, a{4}, sub, true)
             end
+            counter_random_tests(iscertain, n_certain, a{4}, a{2}, false, true)
+            counter_random_tests(iscertain, n_certain, a{2}, a{4}, false, true)
         end
     end
     
     @testset "Gap" begin
         for a in (DNAAlphabet, RNAAlphabet)
-            for sub in (true, false)
-                for n in (4, 2)
+            for n in (4, 2)
+                for sub in (true, false)
                     counter_random_tests(isgap, n_gaps, a{n}, a{n}, sub, true)
                 end
-                counter_random_tests(isgap, n_gaps, a{4}, a{2}, sub, true)
-                counter_random_tests(isgap, n_gaps, a{2}, a{4}, sub, true)
             end
+            counter_random_tests(isgap, n_gaps, a{4}, a{2}, false, true)
+            counter_random_tests(isgap, n_gaps, a{2}, a{4}, false, true)
         end
     end
     

--- a/test/counting.jl
+++ b/test/counting.jl
@@ -42,7 +42,7 @@
     end
     
     function counter_random_tests(pred::Function, alias::Function, alphx::Type{<:Alphabet}, alphy::Type{<:Alphabet}, subset::Bool)
-        for _ in 1:50
+        for _ in 1:20
             seqA = random_seq(alphx, rand(10:100))
             seqB = random_seq(alphy, rand(10:100))
             sa = seqA
@@ -93,6 +93,7 @@
                 counter_random_tests(isambiguous, n_ambiguous, a{2}, a{4}, sub)
             end
         end
+        @test count(isambiguous, LongSequence{DNAAlphabet{2}}("TAG")) == 0 
     end
     
     @testset "Certain" begin

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -98,6 +98,10 @@ end
     src = LongDNA{4}("A"^16 * "C"^16 * "A"^16)
     copyto!(src, 17, src, 1, 32)
     @test String(src) == "A"^32 * "C"^16
+
+    # Can't copy over edge
+    dst = LongDNA{4}("TAGCA")
+    @test_throws Exception copyto!(dst, 1, fill(0x61, 2), 2, 3)
 end
 
 @testset "Copy! data" begin

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -10,6 +10,14 @@
 	sim = similar(seq)
 	@test typeof(sim) == typeof(seq)
 	@test length(sim) == length(seq)
+
+    # Construct from other sequences
+    seq = LongAA("AGCTVMN")
+    @test LongSequence(seq) == LongAA("AGCTVMN")
+    @test LongSequence(seq, 2:5) == LongAA("GCTV")
+    @test LongSequence(SimpleSeq("AUCGU")) isa LongRNA{2}
+    @test LongSequence(SimpleSeq("AUCGU")) == LongRNA{2}("AUCGU")
+    LongDNA{4}(LongRNA{4}("AUCGUA")) == LongDNA{4}("ATCGTA")
 end
 
 @testset "Copy sequence" begin

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -54,8 +54,8 @@ end # testset
     end
 
     # Doesn't work for wrong types
-    @test_throws MethodError copy!(LongDNA{4}("TAG"), LongAA("WGM"))
-    @test_throws MethodError copy!(LongDNA{2}("TAG"), LongRNA{4}("UGM"))
+    @test_throws Exception copy!(LongDNA{4}("TAG"), LongAA("WGM"))
+    @test_throws Exception copy!(LongDNA{2}("TAG"), LongRNA{4}("UGM"))
 end
 
 @testset "Copyto! sequence" begin

--- a/test/longsequences/conversion.jl
+++ b/test/longsequences/conversion.jl
@@ -76,6 +76,13 @@ end
         @test LongSequence{A}(xs) == LongSequence{A}(seq)
     end
 
+    # Construct from abstract vector
+    LongDNA{4}(0x61:0x64) == LongDNA{4}("ABCD")
+    LongDNA{4}(0x61:0x64, 3:4) == LongDNA{4}("CD")
+    LongRNA{2}(0x61:0x61) == LongRNA{2}("A")
+    LongDNA{4}(Test.GenericString("AGCTMYWK")) == LongDNA{4}("AGCTMYWK")
+    LongAA(Test.GenericString("KMSPIYT")) == LongAA("KMSPIYT")
+
     for len in [0, 1, 10, 32, 1000]
         test_vector_construction(DNAAlphabet{4}, random_dna(len))
         test_vector_construction(RNAAlphabet{4}, random_rna(len))

--- a/test/longsequences/hashing.jl
+++ b/test/longsequences/hashing.jl
@@ -45,4 +45,8 @@
     @test hash(rna"AAUUAA"[3:5]) === hash(rna"UUA")
     @test hash(aa"MTTQAPMFTQPLQ") === hash(aa"MTTQAPMFTQPLQ")
     @test hash(aa"MTTQAPMFTQPLQ"[5:10]) === hash(aa"APMFTQ")
+
+	# Test hash of longer view to engange some inner loops
+	seq = randdnaseq(250)
+	@test hash(seq[33:201]) == hash(view(seq, 33:201))
 end

--- a/test/longsequences/seqview.jl
+++ b/test/longsequences/seqview.jl
@@ -22,6 +22,8 @@
 	@test vv == vv2 == vv3
 	vv[1] = AA_V
 	@test vv == vv2 == vv3
+
+	@test LongSubSeq{AminoAcidAlphabet}(seq) == view(seq, eachindex(seq))
 end
 
 @testset "Basics" begin
@@ -81,6 +83,9 @@ end
 	seq = LongRNA{4}("UAUUAACCGGAGAUCAUUCAGGUAA")
 	v1 = view(seq, 1:3)
 	v2 = view(seq, 4:11)
+
+	@test copy(v1) == seq[1:3]
+	@test copy(v2) == seq[4:11]
 
 	# Can't resize views
 	@test_throws Exception copy!(v1, v2)

--- a/test/longsequences/seqview.jl
+++ b/test/longsequences/seqview.jl
@@ -77,6 +77,13 @@ end
 	@test seq2[3:15] == complement(seq[3:15])
 	@test seq2[1:2] == dna"TG"
 	@test seq2[16:end] == seq[16:end]
+
+	# A longer example to engage some inner loops
+	seq = randdnaseq(38)
+	seq2 = copy(seq)
+	v = LongSubSeq(seq, 3:36)
+	complement!(v)
+	@test v == complement(seq2[3:36])
 end
 
 @testset "Copying" begin

--- a/test/translation.jl
+++ b/test/translation.jl
@@ -44,6 +44,19 @@
         @test translate!(aas, seq) == translate(seq)
     end
 
+    # Basics
+    @test length(BioSequences.standard_genetic_code) == 64
+    buf = IOBuffer()
+    show(buf, BioSequences.standard_genetic_code)
+    @test !iszero(length(take!(buf))) # just test it doesn't error
+
+    # TransTables
+    @test BioSequences.TransTables() isa BioSequences.TransTables
+    @test BioSequences.ncbi_trans_table[1] === BioSequences.standard_genetic_code
+    buf = IOBuffer()
+    show(buf, BioSequences.ncbi_trans_table)
+    @test !iszero(length(take!(buf)))
+
     # ambiguous codons
     @test translate(rna"YUGMGG") == aa"LR"
     @test translate(rna"GAYGARGAM") == aa"DEX"


### PR DESCRIPTION
# Improve test coverage for v3

Resolves #139 . During the testing, it is possible some functions may be changed if they are discovered to be broken. This PR will contain an exhaustive list of all non-test changes, that is, changes in the `src` directory,

**Completion**
- [x] Alphabet
- [x] Translation
- [x] BioSequence
- [x] LongSequence
- [x] Bit-manipulation
- [ ] Search  

## Current changes / bugfixes
* `join!` is now exported as it should have been
* Fixed a typo in `join!(::BioSequence, ::Vector)` which caused it to fail
* Renamed `_copyto!` for `BioSequence` to `Base.copyto!`. I don't know why it was an internal method before, honestly.
* Remove `unsafe_setindex!`, which has been kept until now for backwards compatibility
* Fix typo `is_canonical` in `canonical(::BioSequence)`
* Remove outdated `Base.cmp` for `BitIndex`
* Remove unused `extract_encoded_element(::BitIndex, ::NTuple)` and `bitmask(::Type, ::Val)`
* Remove meaningless and non-tested function `LongSequence(it) = LongSequence{eltype(it)}(it)` (was also wrong)
* Changed un-tested constructor `LongSequence{A}(::Union{AbstractString,AbstractVector{UInt8}}, ::Integer, ::Integer)` to take a range instead of two integers for consistency with other constructors
* Remove one copy of duplicated method `bitindex(::LongSubSeq, ::Integer)`
* Remove one copy of duplicated method `encoded_setindex!(::SeqOrView, ::Unsigned, ::Integer)`
* Added missing method `symbols_per_data_element(::LongSubSeq)`
* Change various methods to take `AbstractUnitRange` over `UnitRange` with identical behaviour