### PR TITLE
Small internal refactors

### DIFF
--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -191,7 +191,6 @@ export
 
 using BioSymbols
 import Twiddle: enumerate_nibbles,
-    nibble_mask,
     count_0000_nibbles,
     count_1111_nibbles,
     count_nonzero_nibbles,

--- a/src/bit-manipulation/bit-manipulation.jl
+++ b/src/bit-manipulation/bit-manipulation.jl
@@ -72,7 +72,7 @@ end
 end
 
 @inline function gap_bitcount(x::UInt64, ::T) where {T<:NucleicAcidAlphabet{4}}
-    return count_zero_nibbles(x)
+    return count_0000_nibbles(x)
 end
 
 @inline function gap_bitcount(a::UInt64, b::UInt64, ::T) where {T<:NucleicAcidAlphabet{4}}

--- a/src/bit-manipulation/bitpar-compiler.jl
+++ b/src/bit-manipulation/bitpar-compiler.jl
@@ -25,7 +25,9 @@ function compile_bitpar(funcname::Symbol;
             if !iszero(offset(ind)) & (ind < stop)
                 # align the bit index to the beginning of a block boundary
                 o = offset(ind)
-                chunk = (data[index(ind)] >> o) & bitmask(stop - ind)
+                mask = bitmask(stop - ind)
+                n_bits_masked = ifelse(index(stop) == index(ind), count_zeros(mask), o)
+                chunk = (data[index(ind)] >> o) & mask
                 $(head_code)
                 ind += 64 - o
             end
@@ -39,7 +41,8 @@ function compile_bitpar(funcname::Symbol;
             end
             
             if ind < stop
-                chunk = data[index(ind)] & bitmask(offset(stop))
+                n_bits_masked = 64 - offset(stop)
+                chunk = data[index(ind)] & bitmask(64 - n_bits_masked)
                 $(tail_code)
             end
         end

--- a/src/geneticcode.jl
+++ b/src/geneticcode.jl
@@ -378,7 +378,7 @@ function translate!(aaseq::LongAA,
                 if allow_ambiguous_codons
                     aa = AA_X
                 else
-                    error("codon ", x, y, z, " cannot be unambiguously translated")
+                    error("codon ", a, b, c, " cannot be unambiguously translated")
                 end
             end
             aaseq[i] = aa

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -88,8 +88,3 @@ function (::Type{T})(seq::LongSequence{<:NucleicAcidAlphabet{N}}) where
          {N, T<:LongSequence{<:NucleicAcidAlphabet{N}}}
     return T(copy(seq.data), seq.len)
 end
-
-# This exists to fix ambiguity errors with Julia 1.0
-function LongSequence{A}(seq::LongSequence{<:NucleicAcidAlphabet{N}}) where {N, A <: NucleicAcidAlphabet{N}}
-	return LongSequence{A}(copy(seq.data), seq.len)
-end

--- a/src/longsequences/copying.jl
+++ b/src/longsequences/copying.jl
@@ -132,8 +132,7 @@ function Base.copy!(dst::SeqOrView{A}, src::SeqLike) where {A <: Alphabet}
 end
 
 function Base.copy!(dst::SeqOrView{<:Alphabet}, src::ASCIILike, C::AsciiAlphabet)
-    v = GC.@preserve src unsafe_wrap(Vector{UInt8}, pointer(src), ncodeunits(src))
-    return copy!(dst, v, C)
+    return copy!(dst, codeunits(src), C)
 end
 
 function Base.copy!(dst::SeqOrView{<:Alphabet}, src::AbstractVector{UInt8}, ::AsciiAlphabet)
@@ -199,11 +198,10 @@ function Base.copyto!(dst::SeqOrView{A}, src::SeqLike) where {A <: Alphabet}
 end
 
 # Specialized method to avoid O(N) length call for string-like src
-function Base.copyto!(dst::SeqOrView{<:Alphabet}, src::ASCIILike, C::AsciiAlphabet)
+function Base.copyto!(dst::SeqOrView{<:Alphabet}, src::ASCIILike, ::AsciiAlphabet)
     len = ncodeunits(src)
     @boundscheck checkbounds(dst, 1:len)
-    v = GC.@preserve src unsafe_wrap(Vector{UInt8}, pointer(src), ncodeunits(src))
-    encode_chunks!(dst, 1, v, 1, len)
+    encode_chunks!(dst, 1, codeunits(src), 1, len)
     return dst
 end
 
@@ -241,8 +239,7 @@ end
 function Base.copyto!(dst::SeqOrView{A}, doff::Integer,
                       src::ASCIILike, soff::Integer,
                       N::Integer, C::AsciiAlphabet) where {A <: Alphabet}
-    v = GC.@preserve src unsafe_wrap(Vector{UInt8}, pointer(src), ncodeunits(src))
-    return Base.copyto!(dst, doff, v, soff, N, C)
+    return Base.copyto!(dst, doff, codeunits(src), soff, N, C)
 end
 
 @noinline function throw_enc_indexerr(N::Integer, len::Integer, soff::Integer)

--- a/src/longsequences/counting.jl
+++ b/src/longsequences/counting.jl
@@ -14,7 +14,7 @@ let
         head_code   = counter,
         body_code   = counter,
         tail_code   = counter,
-        return_code = :(return n)
+        return_code = :(return n % Int)
     ) |> eval
 end
 
@@ -32,7 +32,7 @@ let
         head_code = counter,
         body_code = counter,
         tail_code = counter,
-        return_code = :(return count)
+        return_code = :(return count % Int)
     ) |> eval
 end
 Base.count(::typeof(!=), seqa::SeqOrView{A}, seqb::SeqOrView{A}) where {A<:NucleicAcidAlphabet} = count_mismatches_bitpar(seqa, seqb)
@@ -56,7 +56,7 @@ let
         head_code = count_empty,
         body_code = counter,
         tail_code = count_empty,
-        return_code = :(return count)
+        return_code = :(return count % Int)
     ) |> eval
 end
 Base.count(::typeof(==), seqa::SeqOrView{A}, seqb::SeqOrView{A}) where {A<:NucleicAcidAlphabet} = count_matches_bitpar(seqa, seqb)
@@ -74,7 +74,7 @@ let
         head_code   = counter,
         body_code   = counter,
         tail_code   = counter,
-        return_code = :(return count)
+        return_code = :(return count % Int)
     ) |> eval
     
     counter = :(count += ambiguous_bitcount(x, y, A()))
@@ -87,7 +87,7 @@ let
         head_code = counter,
         body_code = counter,
         tail_code = counter,
-        return_code = :(return count)
+        return_code = :(return count % Int)
     ) |> eval
 end
 
@@ -116,7 +116,7 @@ let
         head_code = counter,
         body_code = counter,
         tail_code = counter,
-        return_code = :(return count)
+        return_code = :(return count % Int)
     ) |> eval
 end
 Base.count(::typeof(iscertain), seqa::SeqOrView{A}, seqb::SeqOrView{A}) where {A<:NucleicAcidAlphabet{4}} = count_certain_bitpar(seqa, seqb)
@@ -125,13 +125,30 @@ Base.count(::typeof(iscertain), seqa::SeqOrView{<:NucleicAcidAlphabet{2}}, seqb:
 
 # Counting gap sites
 let
-    counter = :(count += gap_bitcount(x, y, A()))
-    
     count_empty = quote
-        count += gap_bitcount(x, y, A())
-        nempty = div(64, bits_per_symbol(A())) - div(offs, bits_per_symbol(A()))
+        Alph = Alphabet(seq)
+        count += gap_bitcount(chunk, Alph)
+        count -= div(n_bits_masked, bits_per_symbol(Alph))
+    end
+    counter = :(count += gap_bitcount(chunk, Alphabet(seq)))
+    
+    compile_bitpar(
+        :count_gap_bitpar,
+        arguments   = (:(seq::SeqOrView{<:NucleicAcidAlphabet{4}}),),
+        init_code   = :(count = 0),
+        head_code   = count_empty,
+        body_code   = counter,
+        tail_code   = count_empty,
+        return_code = :(return count % Int)
+    ) |> eval
+
+    count_empty = quote
+        Alph = Alphabet(seqa)
+        count += gap_bitcount(x, y, Alph)
+        nempty = div(64, bits_per_symbol(Alph)) - div(offs, bits_per_symbol(Alph))
         count -= nempty
     end
+    counter = :(count += gap_bitcount(x, y, A()))
     
     compile_2seq_bitpar(
         :count_gap_bitpar,
@@ -141,9 +158,10 @@ let
         head_code = count_empty,
         body_code = counter,
         tail_code = count_empty,
-        return_code = :(return count)
+        return_code = :(return count % Int)
     ) |> eval
 end
 Base.count(::typeof(isgap), seqa::SeqOrView{A}, seqb::SeqOrView{A}) where {A<:NucleicAcidAlphabet{4}} = count_gap_bitpar(seqa, seqb)
+Base.count(::typeof(isgap), seqa::SeqOrView{A}) where {A<:NucleicAcidAlphabet{4}} = count_gap_bitpar(seqa)
 Base.count(::typeof(isgap), seqa::SeqOrView{<:NucleicAcidAlphabet{4}}, seqb::SeqOrView{<:NucleicAcidAlphabet{2}}) = count(isgap, promote(seqa, seqb)...)
 Base.count(::typeof(isgap), seqa::SeqOrView{<:NucleicAcidAlphabet{2}}, seqb::SeqOrView{<:NucleicAcidAlphabet{4}}) = count(isgap, promote(seqa, seqb)...)

--- a/src/search/ApproxSearchQuery.jl
+++ b/src/search/ApproxSearchQuery.jl
@@ -84,7 +84,7 @@ Construct an [`ApproximateSearchQuery`](@ref) predicate for use with Base find f
 function ApproximateSearchQuery(pat::S, comparator::F = isequal) where {F<:Function,S<:BioSequence}
     m = length(pat)
     if m > 64
-        throw(ArgumentEror("query pattern sequence must have length of 64 or less"))
+        throw(ArgumentError("query pattern sequence must have length of 64 or less"))
     end
     Σ = alphabet(eltype(pat))
     fw = zeros(UInt64, length(Σ))

--- a/src/search/re.jl
+++ b/src/search/re.jl
@@ -706,7 +706,7 @@ function Base.match(re::Regex{T}, seq::BioSequences.BioSequence, start::Integer=
     while true
         if firstsym != BioSequences.gap(T)
             s = findnext(isequal(firstsym), seq, s)
-            if s == nothing
+            if s === nothing
                 break
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using StatsBase
 using YAML
 
 # Test for the absence of ubound type parameters in the package
-@test length(Test.detect_unbound_args(BioSequences)) == 0
+@test length(Test.detect_unbound_args(BioSequences, recursive=true)) == 0
 
 # Test utils not dependent on BioSymbols
 include("utils.jl")

--- a/test/search/regex.jl
+++ b/test/search/regex.jl
@@ -73,7 +73,7 @@
     @test findfirst(biore"A+"d, dna"ACGTAAT") == 1:1
     @test findfirst(biore"A+"d, dna"ACGTAAT", 1) == 1:1
     @test findfirst(biore"A+"d, dna"ACGTAAT", 2) == 5:6
-    @test findfirst(biore"A+"d, dna"ACGTAAT", 7) == nothing
+    @test findfirst(biore"A+"d, dna"ACGTAAT", 7) === nothing
 
     # eachmatch
     matches = [dna"CG", dna"GC", dna"GC", dna"CG"]


### PR DESCRIPTION
* Bugfix: Fix unbound function call `count_zero_nibbles` to `count_0000_nibbles`
* Bugfix: Fix unbound symbols in ambiguous translation error message
* Implement `count(isgap, ::LongDNA{4})` with bitpar compiler.
  This also exposes previously unused codepaths to test suite.
* Make sure all `count` functions for `LongSequence` returns `Int`
  previously, they sporadically returned `UInt`.
* Replace a bunch of `unsafe_wrap` on strings with `codeunits` for simplicity and safety.
* Remove function kept for unneeded 1.0 compat
* Remove unused import `nibble_mask`
* Various small style improvements