### PR TITLE
Add `findall` method

### DIFF
--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -11,7 +11,7 @@ export
     ###
     ### Symbols
     ###
-    
+
     # Types & aliases
     NucleicAcid,
     DNA,
@@ -81,7 +81,7 @@ export
     AA_X,
     AA_Term,
     AA_Gap,
-    
+
     # Predicates
     isGC,
     iscompatible,
@@ -90,35 +90,35 @@ export
     isgap,
     ispurine,
     ispyrimidine,
-    
+
     ###
     ### Alphabets
     ###
-    
+
     # Types & aliases
     Alphabet,
     NucleicAcidAlphabet,
     DNAAlphabet,
     RNAAlphabet,
     AminoAcidAlphabet,
-    
+
     ###
     ### BioSequences
     ###
 
     join!,
-    
+
     # Type & aliases
     BioSequence,
     NucSeq,
     AASeq,
-    
+
     # Predicates
     ispalindromic,
     hasambiguity,
     isrepetitive,
     iscanonical,
-    
+
     # Transformations
     canonical,
     canonical!,
@@ -129,11 +129,11 @@ export
     ungap,
     ungap!,
     join!,
-    
+
     ###
     ### LongSequence
     ###
-    
+
     # Type & aliases
     LongSequence,
     LongNuc,
@@ -141,7 +141,7 @@ export
     LongRNA,
     LongAA,
     LongSubSeq,
-    
+
     # Random
     SamplerUniform,
     SamplerWeighted,
@@ -149,18 +149,18 @@ export
     randdnaseq,
     randrnaseq,
     randaaseq,
-    
+
     ###
     ### Sequence literals
     ###
-    
+
     @dna_str,
     @rna_str,
     @aa_str,
 
     @biore_str,
     @prosite_str,
-    
+
     BioRegex,
     BioRegexMatch,
     matched,
@@ -177,7 +177,7 @@ export
     translate!,
     translate,
     ncbi_trans_table,
-    
+
     # Search
     ExactSearchQuery,
     ApproximateSearchQuery,
@@ -226,5 +226,47 @@ include("search/ExactSearchQuery.jl")
 include("search/ApproxSearchQuery.jl")
 include("search/re.jl")
 include("search/pwm.jl")
+
+
+
+struct Search{Q,I}
+    query::Q
+    itr::I
+    start::Integer
+    stop::Integer
+    overlap::Bool
+end
+
+const default_overlap = true
+
+search(query, itr, start=firstindex(itr); overlap = default_overlap, stop = lastindex(itr)) = Search(query, itr, start, stop, overlap)
+
+function Base.iterate(itr::Search, state=itr.start)
+    val = findnext(itr.query, itr.itr, state)
+    val === nothing && return nothing
+    last(val) > itr.stop && return nothing
+    state = itr.overlap ? first(val) + 1 : last(val) + 1
+    return val, state
+end
+
+const HasRangeEltype = Union{<:ExactSearchQuery, <:ApproximateSearchQuery, <:Regex}
+
+Base.eltype(::Type{Search{Q,I}}) where {Q<:HasRangeEltype,I} = UnitRange{Int}
+Base.IteratorEltype(::Type{Search{Q,I}}) where {Q<:HasRangeEltype,I} = Base.IteratorEltype(UnitRange{Int})
+
+Base.eltype(::Type{<:Search}) = Int
+Base.IteratorEltype(::Type{<:Search}) = Base.IteratorEltype(Int)
+
+Base.IteratorSize(::Type{<:Search}) = Base.SizeUnknown()
+
+function Base.findall(pat, seq::BioSequence, start::Integer=firstindex(seq); overlap::Bool = default_overlap, stop::Integer = lastindex(seq))
+    return collect(search(pat, seq, start; overlap, stop))
+end
+
+function Base.findall(pat, seq::BioSequence, range::UnitRange{<:Integer}; kwargs...)
+    start = first(range)
+    stop = last(range)
+    return findall(pat, seq, start; stop, kwargs...)
+end
 
 end  # module BioSequences

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -237,9 +237,9 @@ struct Search{Q,I}
     overlap::Bool
 end
 
-const default_overlap = true
+const DEFAULT_OVERLAP = true
 
-search(query, itr, start=firstindex(itr); overlap = default_overlap, stop = lastindex(itr)) = Search(query, itr, start, stop, overlap)
+search(query, itr, start=firstindex(itr); overlap = DEFAULT_OVERLAP, stop = lastindex(itr)) = Search(query, itr, start, stop, overlap)
 
 function Base.iterate(itr::Search, state=itr.start)
     val = findnext(itr.query, itr.itr, state)
@@ -259,7 +259,7 @@ Base.IteratorEltype(::Type{<:Search}) = Base.IteratorEltype(Int)
 
 Base.IteratorSize(::Type{<:Search}) = Base.SizeUnknown()
 
-function Base.findall(pat, seq::BioSequence, start::Integer=firstindex(seq); overlap::Bool = default_overlap, stop::Integer = lastindex(seq))
+function Base.findall(pat, seq::BioSequence, start::Integer=firstindex(seq); overlap::Bool = DEFAULT_OVERLAP, stop::Integer = lastindex(seq))
     return collect(search(pat, seq, start; overlap, stop))
 end
 

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -251,12 +251,8 @@ end
 
 const HasRangeEltype = Union{<:ExactSearchQuery, <:ApproximateSearchQuery, <:Regex}
 
-Base.eltype(::Type{Search{Q,I}}) where {Q<:HasRangeEltype,I} = UnitRange{Int}
-Base.IteratorEltype(::Type{Search{Q,I}}) where {Q<:HasRangeEltype,I} = Base.IteratorEltype(UnitRange{Int})
-
+Base.eltype(::Type{<:Search{Q}}) where {Q<:HasRangeEltype} = UnitRange{Int}
 Base.eltype(::Type{<:Search}) = Int
-Base.IteratorEltype(::Type{<:Search}) = Base.IteratorEltype(Int)
-
 Base.IteratorSize(::Type{<:Search}) = Base.SizeUnknown()
 
 function Base.findall(pat, seq::BioSequence, start::Integer=firstindex(seq); overlap::Bool = DEFAULT_OVERLAP, stop::Integer = lastindex(seq))

--- a/src/longsequences/seqview.jl
+++ b/src/longsequences/seqview.jl
@@ -32,7 +32,7 @@ const NucleicSeqOrView = SeqOrView{<:NucleicAcidAlphabet}
 
 Base.length(v::LongSubSeq) = last(v.part) - first(v.part) + 1
 Base.copy(v::LongSubSeq{A}) where A = LongSequence{A}(v)
- 
+
 encoded_data_eltype(::Type{<:LongSubSeq}) = encoded_data_eltype(LongSequence)
 symbols_per_data_element(x::LongSubSeq) = div(64, bits_per_symbol(Alphabet(x)))
 
@@ -74,7 +74,7 @@ Base.view(seq::SeqOrView, part::AbstractUnitRange) = LongSubSeq(seq, part)
 function LongSequence(s::LongSubSeq{A}) where A
 	_copy_seqview(LongSequence{A}, s)
 end
-	
+
 function LongSequence{A}(seq::LongSubSeq{A}) where {A<:NucleicAcidAlphabet}
 	_copy_seqview(LongSequence{A}, seq)
 end
@@ -100,3 +100,5 @@ end
 function Base.getindex(seq::LongSubSeq, part::AbstractUnitRange{<:Integer})
 	return LongSubSeq(seq, part)
 end
+
+Base.parentindices(seq::LongSubSeq) = (seq.part,)

--- a/test/longsequences/find.jl
+++ b/test/longsequences/find.jl
@@ -28,4 +28,26 @@
     @test findlast(isequal(DNA_A), seq) == 5
     @test findlast(isequal(DNA_N), seq) == 6
     @test findlast(isequal(DNA_T), seq) === nothing
+
+
+    @test findall(DNA_A, dna"GATC") == [2]
+
+    #         0000000001111
+    #         1234567890123
+    seq = dna"NNNNNGATCGATC"
+
+    @test findall(ExactSearchQuery(dna"GATC"), seq) == [6:9, 10:13]
+
+    # Check overlap key argument.
+    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap=false) == [1:4, 6:9, 10:13]
+    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap=true) == [1:4, 2:5, 6:9, 10:13]
+
+    # Check start/stop delimiter.
+    @test findall(ExactSearchQuery(dna"A", iscompatible), seq) == [1:1, 2:2, 3:3, 4:4, 5:5, 7:7, 11:11]
+    @test findall(ExactSearchQuery(dna"A", iscompatible), seq * dna"AA", 6:13) == findall(ExactSearchQuery(dna"A"), seq)
+
+    # Check empty return type.
+    @test findall(DNA_A, dna"GGGG") |> typeof == Vector{Int}
+    @test findall(ExactSearchQuery(dna"A"), dna"GGGG") |> typeof == Vector{UnitRange{Int}}
+
 end

--- a/test/longsequences/find.jl
+++ b/test/longsequences/find.jl
@@ -30,21 +30,21 @@
     @test findlast(isequal(DNA_T), seq) === nothing
 
 
-    @test findall(DNA_A, dna"GATC") == [2]
-
     #         0000000001111
     #         1234567890123
     seq = dna"NNNNNGATCGATC"
 
-    @test findall(ExactSearchQuery(dna"GATC"), seq) == [6:9, 10:13]
+    # Check default search.
+    @test findall(DNA_A, seq) == [7, 11]
+    @test findall(ExactSearchQuery(dna"A"), seq) == [7:7, 11:11]
 
     # Check overlap key argument.
-    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap=false) == [1:4, 6:9, 10:13]
-    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap=true) == [1:4, 2:5, 6:9, 10:13]
+    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap = false) == [1:4, 6:9, 10:13]
+    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap = true) == [1:4, 2:5, 6:9, 10:13]
 
-    # Check start/stop delimiter.
-    @test findall(ExactSearchQuery(dna"A", iscompatible), seq) == [1:1, 2:2, 3:3, 4:4, 5:5, 7:7, 11:11]
-    @test findall(ExactSearchQuery(dna"A", iscompatible), seq * dna"AA", 6:13) == findall(ExactSearchQuery(dna"A"), seq)
+    # Check mapping of indices.
+    @test findall(DNA_A, seq, 7:11) == [7, 11]
+    @test findall(ExactSearchQuery(dna"A"), seq, 7:11) == [7:7, 11:11]
 
     # Check empty return type.
     @test findall(DNA_A, dna"GGGG") |> typeof == Vector{Int}


### PR DESCRIPTION
I reckon this PR fulfils the `findall` method requirements. 

The `findall` method delegates to a `Search` iterator in the implementation. Let me know whether this approach suits and I'll add some docstrings.

Closes #217.