### PR TITLE
Add `findall` method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Twiddle = "1.1.1"
 julia = "1.6"
 
 [extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
@@ -22,4 +23,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [targets]
-test = ["Test", "StatsBase", "YAML", "LinearAlgebra", "StableRNGs"]
+test = ["Documenter", "Test", "StatsBase", "YAML", "LinearAlgebra", "StableRNGs"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,7 @@
 using Documenter, BioSequences
 
+DocMeta.setdocmeta!(BioSequences, :DocTestSetup, :(using BioSequences); recursive=true)
+
 makedocs(
     format = Documenter.HTML(),
     sitename = "BioSequences.jl",
@@ -17,7 +19,8 @@ makedocs(
         "I/O"                            => "io.md",
         "Implementing custom types"      => "interfaces.md"
     ],
-    authors = "Sabrina Jaye Ward, Jakob Nissen, D.C.Jones, Kenta Sato, The BioJulia Organisation and other contributors."
+    authors = "Sabrina Jaye Ward, Jakob Nissen, D.C.Jones, Kenta Sato, The BioJulia Organisation and other contributors.",
+    checkdocs = :all,
 )
 
 deploydocs(

--- a/docs/src/sequence_search.md
+++ b/docs/src/sequence_search.md
@@ -250,6 +250,11 @@ julia> qa = PWMSearchQuery(motifs, 1.0);
 julia> findfirst(qa, subject)
 3
 
+julia> findall(qa, subject)
+3-element Vector{Int64}:
+ 3
+ 5
+ 9
 ```
 
 [Wasserman2004]: https://doi.org/10.1038/nrg1315

--- a/docs/src/sequence_search.md
+++ b/docs/src/sequence_search.md
@@ -16,9 +16,9 @@ There are many ways to search for particular motifs in biological sequences:
 3. Searches where you are looking for sequences that conform to some sort of
    pattern.
 
-Like other Julia sequences such as `Vector`, you can search a `BioSequence` with the `findfirst(predicate, collection)` method pattern. 
+Like other Julia sequences such as `Vector`, you can search a `BioSequence` with the `findfirst(predicate, collection)` method pattern.
 
-All these kinds of searches are provided in BioSequences.jl, and they all 
+All these kinds of searches are provided in BioSequences.jl, and they all
 conform to the `findnext`, `findprev`, and `occursin` patterns established in `Base` for
 `String` and collections like `Vector`.
 
@@ -26,6 +26,29 @@ The exception is searching using the specialised
 regex provided in this package, which as you shall see, conforms to the `match`
 pattern established in `Base` for pcre and `String`s.
 
+## Symbol search
+
+```jldoctest
+julia> seq = dna"ACAGCGTAGCT";
+
+julia> findfirst(DNA_A, seq)
+1
+
+julia> findlast(DNA_A, seq)
+8
+
+findnext(DNA_A, seq, 2)
+3
+
+julia> findprev(DNA_A, seq, 7)
+3
+
+julia> findall(DNA_A, seq)
+3-element Vector{Int64}:
+ 1
+ 3
+ 8
+```
 
 ## Exact search
 
@@ -138,7 +161,7 @@ RegexMatch("CPVPQARG")
 
 A motif can be specified using [position weight
 matrix](https://en.wikipedia.org/wiki/Position_weight_matrix) (PWM) in a
-probabilistic way. 
+probabilistic way.
 This method searches for the first position in the sequence where a score
 calculated using a PWM is greater than or equal to a threshold.
 More formally, denoting the sequence as ``S`` and the PWM value of symbol ``s``

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -11,7 +11,7 @@ export
     ###
     ### Symbols
     ###
-    
+
     # Types & aliases
     NucleicAcid,
     DNA,
@@ -81,7 +81,7 @@ export
     AA_X,
     AA_Term,
     AA_Gap,
-    
+
     # Predicates
     isGC,
     iscompatible,
@@ -90,35 +90,35 @@ export
     isgap,
     ispurine,
     ispyrimidine,
-    
+
     ###
     ### Alphabets
     ###
-    
+
     # Types & aliases
     Alphabet,
     NucleicAcidAlphabet,
     DNAAlphabet,
     RNAAlphabet,
     AminoAcidAlphabet,
-    
+
     ###
     ### BioSequences
     ###
 
     join!,
-    
+
     # Type & aliases
     BioSequence,
     NucSeq,
     AASeq,
-    
+
     # Predicates
     ispalindromic,
     hasambiguity,
     isrepetitive,
     iscanonical,
-    
+
     # Transformations
     canonical,
     canonical!,
@@ -129,11 +129,11 @@ export
     ungap,
     ungap!,
     join!,
-    
+
     ###
     ### LongSequence
     ###
-    
+
     # Type & aliases
     LongSequence,
     LongNuc,
@@ -141,7 +141,7 @@ export
     LongRNA,
     LongAA,
     LongSubSeq,
-    
+
     # Random
     SamplerUniform,
     SamplerWeighted,
@@ -149,18 +149,18 @@ export
     randdnaseq,
     randrnaseq,
     randaaseq,
-    
+
     ###
     ### Sequence literals
     ###
-    
+
     @dna_str,
     @rna_str,
     @aa_str,
 
     @biore_str,
     @prosite_str,
-    
+
     BioRegex,
     BioRegexMatch,
     matched,
@@ -177,7 +177,7 @@ export
     translate!,
     translate,
     ncbi_trans_table,
-    
+
     # Search
     ExactSearchQuery,
     ApproximateSearchQuery,
@@ -226,5 +226,47 @@ include("search/ExactSearchQuery.jl")
 include("search/ApproxSearchQuery.jl")
 include("search/re.jl")
 include("search/pwm.jl")
+
+
+
+struct Search{Q,I}
+    query::Q
+    itr::I
+    start::Integer
+    stop::Integer
+    overlap::Bool
+end
+
+const default_overlap = true
+
+search(query, itr, start=firstindex(itr); overlap = default_overlap, stop = lastindex(itr)) = Search(query, itr, start, stop, overlap)
+
+function Base.iterate(itr::Search, state=itr.start)
+    val = findnext(itr.query, itr.itr, state)
+    val === nothing && return nothing
+    last(val) > itr.stop && return nothing
+    state = itr.overlap ? first(val) + 1 : last(val) + 1
+    return val, state
+end
+
+const HasRangeEltype = Union{<:ExactSearchQuery, <:ApproximateSearchQuery, <:Regex}
+
+Base.eltype(::Type{Search{Q,I}}) where {Q<:HasRangeEltype,I} = UnitRange{Int}
+Base.IteratorEltype(::Type{Search{Q,I}}) where {Q<:HasRangeEltype,I} = Base.IteratorEltype(UnitRange{Int})
+
+Base.eltype(::Type{<:Search}) = Int
+Base.IteratorEltype(::Type{<:Search}) = Base.IteratorEltype(Int)
+
+Base.IteratorSize(::Type{<:Search}) = Base.SizeUnknown()
+
+function Base.findall(pat, seq::BioSequence, start::Integer=firstindex(seq); overlap::Bool = default_overlap, stop::Integer = lastindex(seq))
+    return collect(search(pat, seq, start; overlap, stop))
+end
+
+function Base.findall(pat, seq::BioSequence, range::UnitRange{<:Integer}; kwargs...)
+    start = first(range)
+    stop = last(range)
+    return findall(pat, seq, start; stop, kwargs...)
+end
 
 end  # module BioSequences

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -237,9 +237,9 @@ struct Search{Q,I}
     overlap::Bool
 end
 
-const default_overlap = true
+const DEFAULT_OVERLAP = true
 
-search(query, itr, start=firstindex(itr); overlap = default_overlap, stop = lastindex(itr)) = Search(query, itr, start, stop, overlap)
+search(query, itr, start=firstindex(itr); overlap = DEFAULT_OVERLAP, stop = lastindex(itr)) = Search(query, itr, start, stop, overlap)
 
 function Base.iterate(itr::Search, state=itr.start)
     val = findnext(itr.query, itr.itr, state)
@@ -259,7 +259,7 @@ Base.IteratorEltype(::Type{<:Search}) = Base.IteratorEltype(Int)
 
 Base.IteratorSize(::Type{<:Search}) = Base.SizeUnknown()
 
-function Base.findall(pat, seq::BioSequence, start::Integer=firstindex(seq); overlap::Bool = default_overlap, stop::Integer = lastindex(seq))
+function Base.findall(pat, seq::BioSequence, start::Integer=firstindex(seq); overlap::Bool = DEFAULT_OVERLAP, stop::Integer = lastindex(seq))
     return collect(search(pat, seq, start; overlap, stop))
 end
 

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -220,90 +220,11 @@ include("longsequences/randseq.jl")
 
 include("geneticcode.jl")
 
-
 # Pattern searching in sequences...
 include("search/ExactSearchQuery.jl")
 include("search/ApproxSearchQuery.jl")
 include("search/re.jl")
 include("search/pwm.jl")
-
-
-
-struct Search{Q,I}
-    query::Q
-    itr::I
-    overlap::Bool
-end
-
-const DEFAULT_OVERLAP = true
-
-search(query, itr; overlap = DEFAULT_OVERLAP) = Search(query, itr, overlap)
-
-function Base.iterate(itr::Search, state=firstindex(itr.itr))
-    val = findnext(itr.query, itr.itr, state)
-    val === nothing && return nothing
-    state = itr.overlap ? first(val) + 1 : last(val) + 1
-    return val, state
-end
-
-const HasRangeEltype = Union{<:ExactSearchQuery, <:ApproximateSearchQuery, <:Regex}
-
-Base.eltype(::Type{<:Search{Q}}) where {Q<:HasRangeEltype} = UnitRange{Int}
-Base.eltype(::Type{<:Search}) = Int
-Base.IteratorSize(::Type{<:Search}) = Base.SizeUnknown()
-
-"""
-    findall(pattern, sequence::BioSequence[,rng::UnitRange{Int}]; overlap::Bool=true)
-
-Find all occurrences of `pattern` in `sequence`.
-
-The return value is a vector of ranges of indices where the matching sequences were found.
-If there are no matching sequences, the return is an empty array.
-
-The search is restricted to the specified range when `rng` is set.
-
-With the keyword argument `overlap` set as `true`, the start index for the next search is set to the start of the current match plus one; if set to `false`, the start index for the next search is set to the end of the current match plus one.
-The default value for the keyword argument `overlap` is `true`.
-
-See also [`ExactSearchQuery`](@ref), [`ApproximateSearchQuery`](@ref), [`PWMSearchQuery`](@ref).
-
-# Examples
-```jldoctest
-julia> sequence = dna"ACACACAC"
-8nt DNA Sequence:
-ACACACAC
-
-julia> findall(DNA_A, sequence)
-4-element Vector{Int64}:
- 1
- 3
- 5
- 7
-
-julia> findall(ExactSearchQuery(dna"ACAC"), sequence)
-3-element Vector{UnitRange{Int64}}:
- 1:4
- 3:6
- 5:8
-
-julia> findall(ExactSearchQuery(dna"ACAC"), sequence; overlap=false)
-2-element Vector{UnitRange{Int64}}:
- 1:4
- 5:8
-
-julia> findall(ExactSearchQuery(dna"ACAC"), sequence, 2:7; overlap=false)
-1-element Vector{UnitRange{Int64}}:
- 3:6
-```
-"""
-function Base.findall(pattern, sequence::BioSequence; overlap::Bool = DEFAULT_OVERLAP)
-    return collect(search(pattern, sequence; overlap))
-end
-
-function Base.findall(pattern, sequence::BioSequence, rng::UnitRange{Int}; overlap::Bool = DEFAULT_OVERLAP)
-    v = view(sequence, rng)
-    itr = search(pattern, v; overlap)
-    return map(x->parentindices(v)[1][x], itr)
-end
+include("search/search.jl")
 
 end  # module BioSequences

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -251,12 +251,8 @@ end
 
 const HasRangeEltype = Union{<:ExactSearchQuery, <:ApproximateSearchQuery, <:Regex}
 
-Base.eltype(::Type{Search{Q,I}}) where {Q<:HasRangeEltype,I} = UnitRange{Int}
-Base.IteratorEltype(::Type{Search{Q,I}}) where {Q<:HasRangeEltype,I} = Base.IteratorEltype(UnitRange{Int})
-
+Base.eltype(::Type{<:Search{Q}}) where {Q<:HasRangeEltype} = UnitRange{Int}
 Base.eltype(::Type{<:Search}) = Int
-Base.IteratorEltype(::Type{<:Search}) = Base.IteratorEltype(Int)
-
 Base.IteratorSize(::Type{<:Search}) = Base.SizeUnknown()
 
 function Base.findall(pat, seq::BioSequence, start::Integer=firstindex(seq); overlap::Bool = DEFAULT_OVERLAP, stop::Integer = lastindex(seq))

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -252,13 +252,57 @@ Base.eltype(::Type{<:Search{Q}}) where {Q<:HasRangeEltype} = UnitRange{Int}
 Base.eltype(::Type{<:Search}) = Int
 Base.IteratorSize(::Type{<:Search}) = Base.SizeUnknown()
 
-function Base.findall(pat, seq::BioSequence; overlap::Bool = DEFAULT_OVERLAP)
-    return collect(search(pat, seq; overlap))
+"""
+    findall(pattern, sequence::BioSequence[,rng::UnitRange{Int}]; overlap::Bool=true)
+
+Find all occurrences of `pattern` in `sequence`.
+
+The return value is a vector of ranges of indices where the matching sequences were found.
+If there are no matching sequences, the return is an empty array.
+
+The search is restricted to the specified range when `rng` is set.
+
+With the keyword argument `overlap` set as `true`, the start index for the next search is set to the start of the current match plus one; if set to `false`, the start index for the next search is set to the end of the current match plus one.
+The default value for the keyword argument `overlap` is `true`.
+
+See also [`ExactSearchQuery`](@ref), [`ApproximateSearchQuery`](@ref), [`PWMSearchQuery`](@ref).
+
+# Examples
+```jldoctest
+julia> sequence = dna"ACACACAC"
+8nt DNA Sequence:
+ACACACAC
+
+julia> findall(DNA_A, sequence)
+4-element Vector{Int64}:
+ 1
+ 3
+ 5
+ 7
+
+julia> findall(ExactSearchQuery(dna"ACAC"), sequence)
+3-element Vector{UnitRange{Int64}}:
+ 1:4
+ 3:6
+ 5:8
+
+julia> findall(ExactSearchQuery(dna"ACAC"), sequence; overlap=false)
+2-element Vector{UnitRange{Int64}}:
+ 1:4
+ 5:8
+
+julia> findall(ExactSearchQuery(dna"ACAC"), sequence, 2:7; overlap=false)
+1-element Vector{UnitRange{Int64}}:
+ 3:6
+```
+"""
+function Base.findall(pattern, sequence::BioSequence; overlap::Bool = DEFAULT_OVERLAP)
+    return collect(search(pattern, sequence; overlap))
 end
 
-function Base.findall(pat, seq::BioSequence, rng::UnitRange{Int}; overlap::Bool = DEFAULT_OVERLAP)
-    v = view(seq, rng)
-    itr = search(pat, v; overlap)
+function Base.findall(pattern, sequence::BioSequence, rng::UnitRange{Int}; overlap::Bool = DEFAULT_OVERLAP)
+    v = view(sequence, rng)
+    itr = search(pattern, v; overlap)
     return map(x->parentindices(v)[1][x], itr)
 end
 

--- a/src/longsequences/seqview.jl
+++ b/src/longsequences/seqview.jl
@@ -11,9 +11,11 @@ Modifying the view changes the sequence and vice versa.
 # Examples
 ```jldoctest
 julia> LongSubSeq(dna"TAGA", 2:3)
+2nt DNA Sequence:
 AG
 
-julia view(dna"TAGA", 2:3)
+julia> view(dna"TAGA", 2:3)
+2nt DNA Sequence:
 AG
 ```
 """

--- a/src/longsequences/seqview.jl
+++ b/src/longsequences/seqview.jl
@@ -32,7 +32,7 @@ const NucleicSeqOrView = SeqOrView{<:NucleicAcidAlphabet}
 
 Base.length(v::LongSubSeq) = last(v.part) - first(v.part) + 1
 Base.copy(v::LongSubSeq{A}) where A = LongSequence{A}(v)
- 
+
 encoded_data_eltype(::Type{<:LongSubSeq}) = encoded_data_eltype(LongSequence)
 symbols_per_data_element(x::LongSubSeq) = div(64, bits_per_symbol(Alphabet(x)))
 
@@ -74,7 +74,7 @@ Base.view(seq::SeqOrView, part::AbstractUnitRange) = LongSubSeq(seq, part)
 function LongSequence(s::LongSubSeq{A}) where A
 	_copy_seqview(LongSequence{A}, s)
 end
-	
+
 function LongSequence{A}(seq::LongSubSeq{A}) where {A<:NucleicAcidAlphabet}
 	_copy_seqview(LongSequence{A}, seq)
 end
@@ -100,3 +100,5 @@ end
 function Base.getindex(seq::LongSubSeq, part::AbstractUnitRange{<:Integer})
 	return LongSubSeq(seq, part)
 end
+
+Base.parentindices(seq::LongSubSeq) = (seq.part,)

--- a/src/search/ApproxSearchQuery.jl
+++ b/src/search/ApproxSearchQuery.jl
@@ -28,8 +28,8 @@ julia> seq = dna"ACAGCGTAGCT";
 
 julia> query = ApproximateSearchQuery(dna"AGGG");
 
-julia> findfirst(query, 0, seq)  # nothing matches with no errors
-nothing
+julia> findfirst(query, 0, seq) == nothing # nothing matches with no errors
+true
 
 julia> findfirst(query, 1, seq)  # seq[3:6] matches with one error
 3:6
@@ -59,7 +59,7 @@ julia> findnext(query, 1, dna"AAGNGG", 1) # 1 mismatch permitted (A vs G) & matc
 !!! note
     This method of searching for motifs was implemented with smaller query motifs
     in mind.
-    
+
     If you are looking to search for imperfect matches of longer sequences in this
     manner, you are likely better off using some kind of local-alignment algorithm
     or one of the BLAST variants.
@@ -98,9 +98,9 @@ function ApproximateSearchQuery(pat::S, comparator::F = isequal) where {F<:Funct
     end
     shift = 64 - m
     bw = [bitreverse(i) >>> (shift & 63) for i in fw]
-    
+
     H = Vector{Int}(undef, length(pat) + 1)
-    
+
     return ApproximateSearchQuery{F,S}(comparator, copy(pat), fw, bw, H)
 end
 
@@ -169,7 +169,7 @@ function search_approx_suffix(Pcom::Vector{UInt64}, pat::BioSequence, seq::BioSe
     if k < 0
         throw(ArgumentError("the number of errors must be non-negative"))
     end
-    
+
     m = length(pat)
     n = length(seq)
 
@@ -214,15 +214,15 @@ function alignback!(query::ApproximateSearchQuery{<:Function,<:BioSequence}, seq
     comparator = query.comparator
     H = query.H
     pat = query.seq
-    
+
     m = length(pat)
     n = length(seq)
-    
+
     # initialize the cost column
     for i in 0:m
         H[i + 1] = i
     end
-    
+
     j = ret = matchstop
     found = false
     while (forward && j ≥ max(start, 1)) || (!forward && j ≤ min(start, n))

--- a/src/search/ExactSearchQuery.jl
+++ b/src/search/ExactSearchQuery.jl
@@ -22,6 +22,17 @@ julia> findfirst(query, seq)
 julia> findlast(query, seq)
 8:10
 
+julia> findnext(query, seq, 6)
+8:10
+
+julia> findprev(query, seq, 7)
+3:5
+
+julia> findall(query, seq)
+2-element Vector{UnitRange{Int64}}:
+ 3:5
+ 8:10
+
 julia> occursin(query, seq)
 true
 
@@ -66,17 +77,17 @@ Construct an [`ExactSearchQuery`](@ref) predicate for use with Base find functio
 """
 function ExactSearchQuery(pat::BioSequence, comparator::Function = isequal)
     T = ExactSearchQuery{typeof(comparator),typeof(pat)}
-    
+
     m = length(pat)
     if m == 0
         return T(comparator, pat, UInt64(0), 0, 0)
     end
-    
+
     first = pat[1]
     last = pat[end]
     bloom_mask = zero(UInt64)
     fshift = bshift = m
-    
+
     for i in 1:lastindex(pat)
         x = pat[i]
         bloom_mask |= _bloom_bits(typeof(comparator), x)
@@ -84,14 +95,14 @@ function ExactSearchQuery(pat::BioSequence, comparator::Function = isequal)
             fshift = m - i
         end
     end
-    
+
     for i in lastindex(pat):-1:1
         x = pat[i]
         if comparator(x, first) && i > 1
             bshift = i - 1
         end
     end
-    
+
     return T(comparator, pat, bloom_mask, fshift, bshift)
 end
 
@@ -117,9 +128,9 @@ function quicksearch(query::ExactSearchQuery, seq::BioSequence, start::Integer, 
     comparator = query.comparator
     bloom_mask = query.bloom_mask
     ambig_check = _check_ambiguous(query)
-    
+
     checkeltype(seq, pat)
-    
+
     m = length(pat)
     n = length(seq)
     stop′ = min(stop, n) - m
@@ -166,9 +177,9 @@ function quickrsearch(query::ExactSearchQuery, seq::BioSequence, start::Integer,
     comparator = query.comparator
     bloom_mask = query.bloom_mask
     ambig_check = _check_ambiguous(query)
-    
+
     checkeltype(seq, pat)
-    
+
     m = length(pat)
     n = length(seq)
     stop′ = max(stop - 1, 0)
@@ -255,4 +266,3 @@ Base.findlast(query::ExactSearchQuery, seq::BioSequence) = findprev(query, seq, 
 Return Bool indicating presence of exact match of x in y.
 """
 Base.occursin(x::ExactSearchQuery, y::BioSequence) = quicksearch(x, y, 1, lastindex(y)) != 0
-

--- a/src/search/ExactSearchQuery.jl
+++ b/src/search/ExactSearchQuery.jl
@@ -34,10 +34,12 @@ The default is `isequal`, however, in biology, sometimes we want a more flexible
 comparison to find subsequences of _compatible_ symbols.
 
 ```jldoctest
-julia> findfirst(ExactSearchQuery(dna"CGT", iscompatible), dna"ACNT")  # 'N' matches 'G'
+julia> query = ExactSearchQuery(dna"CGT", iscompatible);
+
+julia> findfirst(query, dna"ACNT")  # 'N' matches 'G'
 2:4
 
-julia> findfirst(ExactSearchQuery(dna"CNT", iscompatible), dna"ACGT")  # 'G' matches 'N'
+julia> findfirst(query, dna"ACGT")  # 'G' matches 'N'
 2:4
 
 julia> occursin(ExactSearchQuery(dna"CNT", iscompatible), dna"ACNT")

--- a/src/search/search.jl
+++ b/src/search/search.jl
@@ -1,0 +1,76 @@
+const DEFAULT_OVERLAP = true
+
+struct Search{Q,I}
+    query::Q
+    itr::I
+    overlap::Bool
+end
+
+search(query, itr; overlap = DEFAULT_OVERLAP) = Search(query, itr, overlap)
+
+function Base.iterate(itr::Search, state=firstindex(itr.itr))
+    val = findnext(itr.query, itr.itr, state)
+    val === nothing && return nothing
+    state = itr.overlap ? first(val) + 1 : last(val) + 1
+    return val, state
+end
+
+const HasRangeEltype = Union{<:ExactSearchQuery, <:ApproximateSearchQuery, <:Regex}
+
+Base.eltype(::Type{<:Search{Q}}) where {Q<:HasRangeEltype} = UnitRange{Int}
+Base.eltype(::Type{<:Search}) = Int
+Base.IteratorSize(::Type{<:Search}) = Base.SizeUnknown()
+
+"""
+    findall(pattern, sequence::BioSequence[,rng::UnitRange{Int}]; overlap::Bool=true)
+
+Find all occurrences of `pattern` in `sequence`.
+
+The return value is a vector of ranges of indices where the matching sequences were found.
+If there are no matching sequences, the return is an empty array.
+
+The search is restricted to the specified range when `rng` is set.
+
+With the keyword argument `overlap` set as `true`, the start index for the next search is set to the start of the current match plus one; if set to `false`, the start index for the next search is set to the end of the current match plus one.
+The default value for the keyword argument `overlap` is `true`.
+
+See also [`ExactSearchQuery`](@ref), [`ApproximateSearchQuery`](@ref), [`PWMSearchQuery`](@ref).
+
+# Examples
+```jldoctest
+julia> sequence = dna"ACACACAC"
+8nt DNA Sequence:
+ACACACAC
+
+julia> findall(DNA_A, sequence)
+4-element Vector{Int64}:
+ 1
+ 3
+ 5
+ 7
+
+julia> findall(ExactSearchQuery(dna"ACAC"), sequence)
+3-element Vector{UnitRange{Int64}}:
+ 1:4
+ 3:6
+ 5:8
+
+julia> findall(ExactSearchQuery(dna"ACAC"), sequence; overlap=false)
+2-element Vector{UnitRange{Int64}}:
+ 1:4
+ 5:8
+
+julia> findall(ExactSearchQuery(dna"ACAC"), sequence, 2:7; overlap=false)
+1-element Vector{UnitRange{Int64}}:
+ 3:6
+```
+"""
+function Base.findall(pattern, sequence::BioSequence; overlap::Bool = DEFAULT_OVERLAP)
+    return collect(search(pattern, sequence; overlap))
+end
+
+function Base.findall(pattern, sequence::BioSequence, rng::UnitRange{Int}; overlap::Bool = DEFAULT_OVERLAP)
+    v = view(sequence, rng)
+    itr = search(pattern, v; overlap)
+    return map(x->parentindices(v)[1][x], itr)
+end

--- a/test/longsequences/find.jl
+++ b/test/longsequences/find.jl
@@ -28,4 +28,26 @@
     @test findlast(isequal(DNA_A), seq) == 5
     @test findlast(isequal(DNA_N), seq) == 6
     @test findlast(isequal(DNA_T), seq) === nothing
+
+
+    @test findall(DNA_A, dna"GATC") == [2]
+
+    #         0000000001111
+    #         1234567890123
+    seq = dna"NNNNNGATCGATC"
+
+    @test findall(ExactSearchQuery(dna"GATC"), seq) == [6:9, 10:13]
+
+    # Check overlap key argument.
+    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap=false) == [1:4, 6:9, 10:13]
+    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap=true) == [1:4, 2:5, 6:9, 10:13]
+
+    # Check start/stop delimiter.
+    @test findall(ExactSearchQuery(dna"A", iscompatible), seq) == [1:1, 2:2, 3:3, 4:4, 5:5, 7:7, 11:11]
+    @test findall(ExactSearchQuery(dna"A", iscompatible), seq * dna"AA", 6:13) == findall(ExactSearchQuery(dna"A"), seq)
+
+    # Check empty return type.
+    @test findall(DNA_A, dna"GGGG") |> typeof == Vector{Int}
+    @test findall(ExactSearchQuery(dna"A"), dna"GGGG") |> typeof == Vector{UnitRange{Int}}
+
 end

--- a/test/longsequences/find.jl
+++ b/test/longsequences/find.jl
@@ -30,21 +30,21 @@
     @test findlast(isequal(DNA_T), seq) === nothing
 
 
-    @test findall(DNA_A, dna"GATC") == [2]
-
     #         0000000001111
     #         1234567890123
     seq = dna"NNNNNGATCGATC"
 
-    @test findall(ExactSearchQuery(dna"GATC"), seq) == [6:9, 10:13]
+    # Check default search.
+    @test findall(DNA_A, seq) == [7, 11]
+    @test findall(ExactSearchQuery(dna"A"), seq) == [7:7, 11:11]
 
     # Check overlap key argument.
-    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap=false) == [1:4, 6:9, 10:13]
-    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap=true) == [1:4, 2:5, 6:9, 10:13]
+    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap = false) == [1:4, 6:9, 10:13]
+    @test findall(ExactSearchQuery(dna"GATC", iscompatible), seq; overlap = true) == [1:4, 2:5, 6:9, 10:13]
 
-    # Check start/stop delimiter.
-    @test findall(ExactSearchQuery(dna"A", iscompatible), seq) == [1:1, 2:2, 3:3, 4:4, 5:5, 7:7, 11:11]
-    @test findall(ExactSearchQuery(dna"A", iscompatible), seq * dna"AA", 6:13) == findall(ExactSearchQuery(dna"A"), seq)
+    # Check mapping of indices.
+    @test findall(DNA_A, seq, 7:11) == [7, 11]
+    @test findall(ExactSearchQuery(dna"A"), seq, 7:11) == [7:7, 11:11]
 
     # Check empty return type.
     @test findall(DNA_A, dna"GGGG") |> typeof == Vector{Int}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 module TestBioSequences
 
 using Test
+using Documenter
+
 using Random
 using StableRNGs
 using LinearAlgebra: normalize
@@ -49,5 +51,9 @@ include("counting.jl")
     include("search/regex.jl")
     include("search/pwm.jl")
 end
+
+# Include doctests.
+DocMeta.setdocmeta!(BioSequences, :DocTestSetup, :(using BioSequences); recursive=true)
+doctest(BioSequences; manual = false)
 
 end


### PR DESCRIPTION
This PR:
- adds a docblock to the findall method.
- expands find examples where possible.
- adds doctests to unit tests.
- includes minor doctest corrections.
- enables `checkdocs` for build docs.