### PR TITLE
Fix small errors

### DIFF
--- a/src/geneticcode.jl
+++ b/src/geneticcode.jl
@@ -33,7 +33,7 @@ function Base.getindex(code::GeneticCode, codon::UInt64)
     return @inbounds code.tbl[codon + one(UInt64)]
 end
 
-Base.copy(code::GeneticCode) = GeneticCode(copy(code.name), copy(code.tbl))
+Base.copy(code::GeneticCode) = code
 Base.length(code::GeneticCode) = 64
 
 Base.show(io::IO, code::GeneticCode) = print(io, code.name)

--- a/src/search/re.jl
+++ b/src/search/re.jl
@@ -585,7 +585,7 @@ Biological regular expression to seatch for `pattern` in sequences of type `T`, 
 `T` can be `DNA`, `RNA`, and `AminoAcid`. `syntax` can be `:pcre` or `:prosite` for AminoAcid
 acids.
 """
-struct Regex{T}
+struct Regex{T <: Union{BioSequences.DNA, BioSequences.RNA, BioSequences.AminoAcid}}
     pat::String       # regular expression pattern (for printing)
     code::Vector{Op}  # compiled code
     nsaves::Int       # the number of `save` operations in `code`
@@ -616,10 +616,8 @@ function Base.show(io::IO, re::Regex{T}) where {T}
         opt = "dna"
     elseif T == BioSequences.RNA
         opt = "rna"
-    elseif T == BioSequences.AminoAcid
+    else T == BioSequences.AminoAcid
         opt = "aa"
-    else
-        assert(false)
     end
     print(io, "biore\"", re.pat, "\"", opt)
 end


### PR DESCRIPTION
These errors were caught by JET's automatic analysis of packages (it's awesome you guys).
`GeneticCode` is immutable and need not support `copy`, but it's kept as a noop for compatibility.
`Regex` really needs one of these three types, the code assumes them, so we might as well enforce it at compile time.