### PR TITLE
Sequence hashing: Bugfix and slight simplification

### DIFF
--- a/test/longsequences/hashing.jl
+++ b/test/longsequences/hashing.jl
@@ -49,4 +49,7 @@
 	# Test hash of longer view to engange some inner loops
 	seq = randdnaseq(250)
 	@test hash(seq[33:201]) == hash(view(seq, 33:201))
+    @test hash(seq[23:201]) == hash(view(seq, 23:201))
+    @test hash(seq[37:249]) == hash(view(seq, 23:249))
+    @test hash(seq[50:250]) == hash(view(seq, 50:250))
 end


### PR DESCRIPTION
Slightly simplify hashing code and fix a minor bug:
* Replace manual bitrotate code with Base.bitrotate (from Julia 1.5)
* Fix an error from a typo in in murmur2 function
* Slightly simplify the code
* Improve test coverage

This results in a ~12% speed increase on my computer for large sequences, but 9% decrease for short sequences. Might just be measurement noise.