### PR TITLE
Allow join to work with BioSymbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Added
+* It is now possible to `join` BioSymbols into a BioSequence.
+
 ## [3.0.1]
 ### Removed
 

--- a/test/biosequences/biosequence.jl
+++ b/test/biosequences/biosequence.jl
@@ -49,10 +49,16 @@ random_simple(len::Integer) = SimpleSeq(rand([RNA_A, RNA_C, RNA_G, RNA_U], len))
 
     seq2 = SimpleSeq([RNA_U, RNA_C, RNA_U])
     gen = (i for i in [seq, seq2])
-    @test join!(SimpleSeq([]), [seq, seq2]) == SimpleSeq([RNA(i) for i in "CGUUCU"])
-    @test join!(SimpleSeq([]), gen) == SimpleSeq([RNA(i) for i in "CGUUCU"])
+    newseq = SimpleSeq([])
+    join!(newseq, [seq, seq2])
+    @test newseq == SimpleSeq([RNA(i) for i in "CGUUCU"]) 
+    join!(newseq, gen)
+    @test newseq == SimpleSeq([RNA(i) for i in "CGUUCU"])
+    join!(newseq, [RNA_U, RNA_C, SimpleSeq([RNA_G, RNA_C])])
+    @test newseq == SimpleSeq([RNA(i) for i in "UCGC"])
     @test join(SimpleSeq, [seq, seq2]) == join!(SimpleSeq([]), [seq, seq2])
     @test join(SimpleSeq, gen) == join!(SimpleSeq([]), gen)
+    @test join(SimpleSeq, [RNA_U, RNA_G, seq, RNA_U]) == SimpleSeq([RNA(i) for i in "UGCGUU"]) 
 
     @test copy!(SimpleSeq([]), seq) == seq
     seq3 = copy(seq2)

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -263,6 +263,11 @@ end
 
     base_aa_seq = aa"KMAEEHPAIYWLMN"
     test_join(LongAA, (aa"KMVLE", aa"", (@view base_aa_seq[3:6])), aa"KMVLEAEEH")
+
+    # Joining seqs and symbols
+    test_join(LongAA, [AA_G, AA_P, AA_L, aa"MNVWEED", AA_K], aa"GPLMNVWEEDK")
+    test_join(LongRNA{4}, [RNA_M, RNA_U, RNA_S, rna"AGCGSK"], rna"MUSAGCGSK")
+    test_join(LongDNA{2}, [dna"ATGCTTA", DNA_G, DNA_G, DNA_A, DNA_A, DNA_A], dna"ATGCTTAGGAAA")
 end
 
 @testset "Length" begin


### PR DESCRIPTION
# Allow `join` to work with `BioSymbol`

Previously, it was only possible to join BioSequences. Now, one can call
join(LongRNA{2}, (RNA_U, rna"AGCA")) and have it work.
Also skip unneeded calls to resize! when joining

Example use:
```
julia> join(LongDNA{2}, [dna"AA", DNA_G, RNA_U])
4nt DNA Sequence:
AAGT
```

Closes #230 

## Types of changes
This PR implements the following changes:

* [X] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

## :ballot_box_with_check: Checklist
- [X] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [X] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [X] :ok: There are unit tests that cover the code changes I have made.
- [X] :ok: The unit tests cover my code changes AND they pass.
- [X] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [X] :ok: All changes should be compatible with the latest stable version of Julia.
- [X] :thought_balloon: I have commented liberally for any complex pieces of internal code.
