### PR TITLE
Fix ambiguity errors

### DIFF
--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -256,6 +256,9 @@ function Base.findall(pat, seq::BioSequence; overlap::Bool = DEFAULT_OVERLAP)
     return collect(search(pat, seq; overlap))
 end
 
+# Fix ambiguity with Base's findall
+Base.findall(f::Function, seq::BioSequence) = collect(search(f, seq; overlap=DEFAULT_OVERLAP))
+
 function Base.findall(pat, seq::BioSequence, rng::UnitRange{Int}; overlap::Bool = DEFAULT_OVERLAP)
     v = view(seq, rng)
     itr = search(pat, v; overlap)

--- a/src/biosequence/conversion.jl
+++ b/src/biosequence/conversion.jl
@@ -11,6 +11,10 @@ function (::Type{S})(seq::BioSequence) where {S <: AbstractString}
     _string(S, seq, codetype(Alphabet(seq)))
 end
 
+@static if VERSION >= v"1.8"
+    LazyString(seq::BioSequence) = LazyString(string(seq))
+end
+
 function _string(::Type{S}, seq::BioSequence, ::AlphabetCode) where {S<:AbstractString}
     return S([Char(x) for x in seq])
 end

--- a/src/biosequence/conversion.jl
+++ b/src/biosequence/conversion.jl
@@ -12,7 +12,7 @@ function (::Type{S})(seq::BioSequence) where {S <: AbstractString}
 end
 
 @static if VERSION >= v"1.8"
-    LazyString(seq::BioSequence) = LazyString(string(seq))
+    Base.LazyString(seq::BioSequence) = LazyString(string(seq))
 end
 
 function _string(::Type{S}, seq::BioSequence, ::AlphabetCode) where {S<:AbstractString}

--- a/test/longsequences/conversion.jl
+++ b/test/longsequences/conversion.jl
@@ -67,6 +67,11 @@ end
     @test_throws Exception LongDNA{4}("ACCNNCATTTTTTAGATXATAG")
     @test_throws Exception LongRNA{4}("ACCNNCATTTTTTAGATXATAG")
     @test_throws Exception LongAA("ATGHLMY@ZACAGNM")
+
+    # LazyString from BioSequence
+    @static if VERSION >= v"1.8"
+        @test string(LazyString(aa"MQLLCP")) == "MQLLCP"
+    end
 end
 
 @testset "Construction from vectors" begin

--- a/test/longsequences/find.jl
+++ b/test/longsequences/find.jl
@@ -50,4 +50,8 @@
     @test findall(DNA_A, dna"GGGG") |> typeof == Vector{Int}
     @test findall(ExactSearchQuery(dna"A"), dna"GGGG") |> typeof == Vector{UnitRange{Int}}
 
+    @test findall(isequal(DNA_A), dna"ACGTAC") == [1, 5]
+    @test findall(i -> true, aa"ACGTA") == collect(1:5)
+    @test findall(i -> true, aa"") == Int[]
+    @test findall(i -> i == AA_A, rna"AGCA") == Int[]
 end


### PR DESCRIPTION
This is a purely internal change, fixing ambiguity errors.

Julia 1.8 introduces LazyString, which is useful in error throwing code.
However, due to a blanket implementation BioSequence(::AbstractString) in
BioSequences, and a blanket implementation `LazyString(::Any) in Base,
`LazyString(::BioSequence)` is ambiguous. Fix that

Also fix ambiguity with `findall(::Function, ::BioSequence)`, which was not
properly tested. Add tests