### PR TITLE
Add tryencode and trydecode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 * It is now possible to `join` BioSymbols into a BioSequence.
+* Added non-exported functions `trydecode` and `tryencode`.
 
 ## [3.0.1]
 ### Removed

--- a/src/alphabet.jl
+++ b/src/alphabet.jl
@@ -96,6 +96,8 @@ iscomplete(A::Alphabet) = Val(length(symbols(A)) === 1 << bits_per_symbol(A))
 
 Encode BioSymbol `S` to an internal representation using an `Alphabet`.
 This decoding is checked to enforce valid data element.
+
+See also: `decode`[@ref], `tryencode`[@ref], `trydecode`[@ref]
 """
 @inline function encode(A::Alphabet, s::BioSymbol)
     y = tryencode(A, s)
@@ -107,6 +109,8 @@ end
 
 Try encoding BioSymbol `S` to the internal representation of `Alphabet`,
 returning `nothing` if not successful.
+
+See also: `encode`[@ref], `decode`[@ref], `trydecode`[@ref]
 """
 function tryencode end
 
@@ -125,11 +129,23 @@ end
 
 Decode internal representation `E` to a `BioSymbol` using an `Alphabet`.
 This decoding is checked to enforce valid biosymbols.
+
+See also: `encode`[@ref], `trydecode`[@ref], `tryencode`[@ref]
 """
 @inline function decode(A::Alphabet, x)
     y = trydecode(A, x)
     y === nothing ? throw(DecodeError(A, x)) : y
 end
+
+"""
+    trydecode(::Alphabet, x::E)
+
+Decode internal representation `E` to a `BioSymbol` using an `Alphabet`,
+returning `nothing` if not successful.
+
+See also: `decode`[@ref], `encode`[@ref], `tryencode`[@ref]
+"""
+function trydecode end
 
 struct DecodeError{A<:Alphabet,T} <: Exception
     val::T

--- a/src/alphabet.jl
+++ b/src/alphabet.jl
@@ -22,6 +22,7 @@ and T for a DNA Alphabet that requires only 2 bits to represent each symbol.
   of the alphabet's element type, as well as the decoding, the inverse process.
 * An `Alphabet`'s `encode` and `decode` methods must not produce invalid data. 
 
+### Requires methods
 Every subtype `A` of `Alphabet` must implement:
 * `Base.eltype(::Type{A})::Type{S}` for some eltype `S`, which must be a `BioSymbol`.
 * `symbols(::A)::Tuple{Vararg{S}}`. This gives tuples of all symbols in the set of `A`.
@@ -31,11 +32,13 @@ Every subtype `A` of `Alphabet` must implement:
   on `Alphabet` should operate on instances of the alphabet, not the type.
 
 If you want interoperation with existing subtypes of `BioSequence`,
-the encoded representation `E` must be of type `UInt`, and you must also implement:
-* `BitsPerSymbol(::A)::BitsPerSymbol{N}`, where the `N` must be zero
-  or a power of two in [1, 2, 4, 8, 16, 32, [64 for 64-bit systems]].
+the encoded representation `E` must be of type `UInt`, and you must also implement
+`BitsPerSymbol`
 
-For increased performance, see [`AsciiAlphabet`](@ref)
+### Optional methods
+* `BitsPerSymbol` for compatibility with existing `BioSequence`s
+* `AsciiAlphabet` for increased printing/writing efficiency
+* `tryencode` and `trydecode` for fallible de/encoding.
 """
 abstract type Alphabet end
 
@@ -69,8 +72,16 @@ The number of bits required to represent a packed symbol encoding in a vector of
 bits_per_symbol(A::Alphabet) = bits_per_symbol(BitsPerSymbol(A))
 Base.length(A::Alphabet) = length(symbols(A))
 
-## Bits per symbol
+"""
+    BitsPerSymbol{N}
 
+A trait object specifying the number of bits it takes to encode a biosymbol in an `Alphabet`
+Alphabets `A` should implement `BitsPerSymbol(::A)`.
+For compatibility with existing BioSequences, the number of bits should be a power of two
+between 1 and 32, both inclusive.
+
+See also: [`Alphabet`](@ref)
+"""
 struct BitsPerSymbol{N} end
 bits_per_symbol(::BitsPerSymbol{N}) where N = N
 

--- a/test/alphabet.jl
+++ b/test/alphabet.jl
@@ -45,6 +45,7 @@ end
 end
 
 encode = BioSequences.encode
+tryencode = BioSequences.tryencode
 EncodeError = BioSequences.EncodeError
 decode = BioSequences.decode
 DecodeError = BioSequences.DecodeError
@@ -118,11 +119,22 @@ end
         @test_throws EncodeError encode(DNAAlphabet{2}(), DNA_N)
         @test_throws EncodeError encode(DNAAlphabet{2}(), DNA_Gap)
 
+        @test tryencode(DNAAlphabet{2}(), DNA_A) == UInt(0x00)
+        @test tryencode(DNAAlphabet{2}(), DNA_C) == UInt(0x01)
+        @test tryencode(DNAAlphabet{2}(), DNA_G) == UInt(0x02)
+        @test tryencode(DNAAlphabet{2}(), DNA_T) == UInt(0x03)
+        @test tryencode(DNAAlphabet{2}(), DNA_M) === nothing
+        @test tryencode(DNAAlphabet{2}(), DNA_N) === nothing
+        @test tryencode(DNAAlphabet{2}(), DNA_Gap) === nothing
+        @test_throws MethodError tryencode(DNAAlphabet{2}(), RNA_G)
+
         # 4 bits
         for nt in BioSymbols.alphabet(DNA)
             @test encode(DNAAlphabet{4}(), nt) === UInt(reinterpret(UInt8, nt))
+            @test tryencode(DNAAlphabet{4}(), nt) ===  UInt(reinterpret(UInt8, nt))
         end
         @test_throws EncodeError encode(DNAAlphabet{4}(), reinterpret(DNA, 0b10000))
+        @test tryencode(DNAAlphabet{4}(), reinterpret(DNA, 0b10000)) === nothing
     end
 
     @testset "RNA" begin
@@ -135,19 +147,33 @@ end
         @test_throws EncodeError encode(RNAAlphabet{2}(), RNA_N)
         @test_throws EncodeError encode(RNAAlphabet{2}(), RNA_Gap)
 
+        @test tryencode(RNAAlphabet{2}(), RNA_A) == UInt(0x00)
+        @test tryencode(RNAAlphabet{2}(), RNA_C) == UInt(0x01)
+        @test tryencode(RNAAlphabet{2}(), RNA_G) == UInt(0x02)
+        @test tryencode(RNAAlphabet{2}(), RNA_U) == UInt(0x03)
+        @test tryencode(RNAAlphabet{2}(), RNA_M) === nothing
+        @test tryencode(RNAAlphabet{2}(), RNA_N) === nothing
+        @test tryencode(RNAAlphabet{2}(), RNA_Gap) === nothing
+        @test_throws MethodError tryencode(RNAAlphabet{2}(), DNA_G)
+
         # 4 bits
         for nt in BioSymbols.alphabet(RNA)
             @test encode(RNAAlphabet{4}(), nt) === UInt(reinterpret(UInt8, nt))
+            @test tryencode(RNAAlphabet{4}(), nt) ===  UInt(reinterpret(UInt8, nt))
         end
         @test_throws EncodeError encode(RNAAlphabet{4}(), reinterpret(RNA, 0b10000))
+        @test tryencode(RNAAlphabet{4}(), reinterpret(RNA, 0b10000)) === nothing
     end
 
     @testset "AminoAcid" begin
         @test encode(AminoAcidAlphabet(), AA_A) === UInt(0x00)
         for aa in BioSymbols.alphabet(AminoAcid)
             @test encode(AminoAcidAlphabet(), aa) === convert(UInt, reinterpret(UInt8, aa))
+            @test tryencode(AminoAcidAlphabet(), aa) === convert(UInt, reinterpret(UInt8, aa))
         end
         @test_throws BioSequences.EncodeError encode(AminoAcidAlphabet(), BioSymbols.AA_INVALID)
+        @test tryencode(AminoAcidAlphabet(), reinterpret(AminoAcid, typemax(UInt8))) === nothing
+        @test tryencode(AminoAcidAlphabet(), BioSymbols.AA_INVALID) === nothing
     end
 end
 


### PR DESCRIPTION
# Add tryencode and trydecode

The encode and decode methods are not allowed to produce invalid data. Instead,
they throw an error when encountering invalid input data.
This can lead to some frustration when checking if a symbol is permitted in an
alphabet.
One way to solve it is by checking `symbol in symbols(A)`, but this is not
particularly effective.

This PR adds a tryencode and trydecode method to existing alphabets. These
methods return nothing when given invalid data.
Methods encode and decode now internally call their try-variants.

May solve #219

## Types of changes

This PR implements the following changes:
* [X] :sparkles: New feature (A non-breaking change which adds functionality).

## :clipboard: Additional detail
* `tryencode` and `trydecode` introduced, returning `Union{Nothing, E}`
* `encode` and `decode` now uses a fallback implementation which calls these try- methods internally
* There is no performance difference
* Alphabet docstring has been changed in a backwards compatible way to mention these new methods.

## :ballot_box_with_check: Checklist
- [X] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [X] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [X] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [X] :ok: There are unit tests that cover the code changes I have made.
- [X] :ok: The unit tests cover my code changes AND they pass.
- [X] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [X] :ok: All changes should be compatible with the latest stable version of Julia.
- [X] :thought_balloon: I have commented liberally for any complex pieces of internal code.
