### PR TITLE
Schedule method for removal

### DIFF
--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -46,7 +46,7 @@ Base.empty(::Type{T}) where {T <: LongSequence} = T(UInt[], UInt(0))
 
 # Constructors from other sequences
 
-@static if VERSION < v"2"
+@static if VERSION < v"4"
     # TODO: Remove this method, since the user can just slice
     LongSequence(s::LongSequence, xs::AbstractUnitRange{<:Integer}) = s[xs]
 end

--- a/src/longsequences/constructors.jl
+++ b/src/longsequences/constructors.jl
@@ -45,9 +45,12 @@ Base.empty(::Type{T}) where {T <: LongSequence} = T(UInt[], UInt(0))
 (::Type{T})() where {T <: LongSequence} = empty(T)
 
 # Constructors from other sequences
-# TODO: Remove this method, since the user can just slice
-LongSequence(s::LongSequence, xs::AbstractUnitRange{<:Integer}) = s[xs]
 
+@static if VERSION < v"2"
+    # TODO: Remove this method, since the user can just slice
+    LongSequence(s::LongSequence, xs::AbstractUnitRange{<:Integer}) = s[xs]
+end
+        
 function LongSequence(seq::BioSequence{A}) where {A <: Alphabet}
     return LongSequence{A}(seq)
 end


### PR DESCRIPTION
I'm unsure whether this suggestion is a good way to go about planned deprecation. The idea is that if removal is forgotten or missed, the method won't occur in the v2 API. What do you think?

cc: @jakobnissen