### PR TITLE
Use naive hash fallback for BioSequence

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BioSequences"
 uuid = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 authors = ["Sabrina Jaye Ward <sabrinajward@protonmail.com>", "Jakob Nissen <jakobnybonissen@gmail.com>"]
-version = "3.0.1"
+version = "3.0.2"
 
 [deps]
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"

--- a/src/biosequence/biosequence.jl
+++ b/src/biosequence/biosequence.jl
@@ -93,6 +93,7 @@ Base.isempty(x::BioSequence) = iszero(length(x))
 Base.empty(::Type{T}) where {T <: BioSequence} = T(eltype(T)[])
 Base.empty(x::BioSequence) = empty(typeof(x))
 BitsPerSymbol(x::BioSequence) = BitsPerSymbol(Alphabet(typeof(x)))
+Base.hash(s::BioSequence, x::UInt) = foldl((a, b) -> hash(b, a), s, init=x)
 
 function Base.similar(seq::BioSequence, len::Integer=length(seq))
     return typeof(seq)(undef, len)

--- a/src/longsequences/hash.jl
+++ b/src/longsequences/hash.jl
@@ -15,6 +15,8 @@
 ### This file is a part of BioJulia.
 ### License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
+# NB NOTE: This entire file is commented out until issue #243 is resolved
+#=
 const c1 = 0x87c37b91114253d5
 const c2 = 0x4cf5ad432745937f
 
@@ -173,3 +175,4 @@ function Base.hash(seq::SeqOrView, seed::UInt64)
 
     return h1
 end
+=#


### PR DESCRIPTION
Current hashing behaviour hashes equal biosequences with different encodings to
different values, which violate the interface of hash.
This is a fix until (and if) we figure out a better method of hashing.

See issue #243

Going to immediately release this as a new version if tests pass, cc @kescobo @SabrinaJaye 