### PR TITLE
Reset Julia compat to v1.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Twiddle = "7200193e-83a8-5a55-b20d-5d36d44a0795"
 BioSymbols = "5.1.0"
 StableRNGs = "0.1, 1.0"
 Twiddle = "1.1.1"
-julia = "1.6"
+julia = "1.5"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/biosequence/biosequence.jl
+++ b/src/biosequence/biosequence.jl
@@ -101,7 +101,7 @@ end
 
 # Fast path for iterables we know are stateless
 function join!(seq::BioSequence, it::Union{Vector, Tuple, Set})
-    _join!(resize!(seq, sum(joinlen, it, init=0)), it, Val(true))
+    _join!(resize!(seq, reduce((a, b) -> a + joinlen(b), it, init=0)), it, Val(true))
 end
 
 """
@@ -155,7 +155,7 @@ TAGAAC
 see also [`join!`](@ref)
 """
 function Base.join(::Type{T}, it::Union{Vector, Tuple, Set}) where {T <: BioSequence}
-    _join!(T(undef, sum(joinlen, it, init=0)), it, Val(true))
+    _join!(T(undef, reduce((a, b) -> a + joinlen(b), it, init=0)), it, Val(true))
 end
 
 # length is intentionally not implemented for BioSymbol


### PR DESCRIPTION
Commit 3c8f501 changed Julia compat to from 1.5 to 1.6, since the join method
used sum with init keyword, which was introduced in Julia 1.6.
However, BioSequences v3.0.0 was released with Julia compat 1.5. Upping Julia
compat in a patch release is not allowed. Hence, the fix from commit 3c8f501
is not applied in any released version.

This commit resets Julia compat to 1.5, and rephrases the join method so it no
longer uses any features not present in Julia 1.5. It has been tested with Julia
v 1.5 and passes.
