### PR TITLE
Improve robustness of rand tests

### DIFF
--- a/test/longsequences/randseq.jl
+++ b/test/longsequences/randseq.jl
@@ -132,7 +132,7 @@ end # SamplerWeighted
     test_isseq(seq, DNAAlphabet{2}, 25)
 
     # Test that rand! correctly works
-    seq = LongDNA{4}("ATGCTAMWKSSWKHHNNNATVVCGATC")
+    seq = LongDNA{4}("ATGCTAMWKSSWKHHNNNATVVCGATADGCTTWWSYKMMNKATCGACTAYSWTACCCGATC")
     Random.rand!(seq)
     @test Set(seq) == Set(symbols(DNAAlphabet{2}()))
 


### PR DESCRIPTION
This changes the probability of a random CI failure from 0.1% (I just randomly observed it) to 1e-8.