### PR TITLE
Fix bug in zero_offset! called when materializing seqview

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BioSequences"
 uuid = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 authors = ["Sabrina Jaye Ward <sabrinajward@protonmail.com>", "Jakob Nissen <jakobnybonissen@gmail.com>"]
-version = "3.1.1"
+version = "3.1.2"
 
 [deps]
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"

--- a/src/longsequences/transformations.jl
+++ b/src/longsequences/transformations.jl
@@ -74,6 +74,7 @@ end
 
 @inline function zero_offset!(seq::LongSequence{A}, offs::UInt) where A <: Alphabet
     isempty(seq) && return seq
+    iszero(offs) && return seq
     rshift = offs
     lshift = 64 - rshift
     len = length(seq.data)

--- a/test/longsequences/seqview.jl
+++ b/test/longsequences/seqview.jl
@@ -41,6 +41,25 @@ end
 	@test String(seq) == "ANKYH"
 end
 
+# Added after issue 260
+@testset "Random construction" begin
+	for i in 1:100
+		seq = randdnaseq(rand(15:65))
+		begin_ = min(lastindex(seq), rand(10:30))
+		range = begin_:min(lastindex(seq), begin_ + rand(0:40))
+		seq2 = view(seq, range)
+		@test seq2 isa LongSubSeq{typeof(Alphabet(seq))}
+		seq3 = LongSequence(seq2)
+		@test typeof(seq) == typeof(seq3)
+		@test seq[range] == seq2 == seq3
+	end
+
+	# See issue 260
+	seq = dna"CATTTTTTTTTTTTTTT"
+	seq2 = LongSequence(LongSubSeq(seq, 1:17))
+	@test seq == seq2
+end
+
 @testset "Conversion" begin
 	seq = LongDNA{4}("TAGTATCGAAMYCGNA")
 	v = LongSubSeq(seq, 3:14)


### PR DESCRIPTION
When materializing a seqview, a slice of the underlying buffer is copied directly, for efficiency. Since the bytes may be placed in the buffer with a nonzero offset, the optimised zero_offset! is called. However, a bug in zero_offset! meant that it did not behave correctly when the offset was already zero.

Fix #260 