### PR TITLE
Allow translation of sequence views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED]
+### Added
+* `LongSubSeq{<:NucleicAcidAlphabet}` can now be translated.
 
 ## [3.1.0]
 ### Added

--- a/test/translation.jl
+++ b/test/translation.jl
@@ -41,7 +41,7 @@
     for len in [1, 10, 32, 1000, 10000, 100000]
         @test all(Bool[check_translate(random_translatable_rna(len)) for _ in 1:reps])
         seq = LongDNA{4}(LongRNA{4}(random_translatable_rna(len)))
-        @test translate!(aas, seq) == translate(seq)
+        @test translate!(aas, seq) == translate(seq) == translate(view(seq, 1:lastindex(seq)))
     end
 
     # Basics


### PR DESCRIPTION
See #263 

This PR extends existing `translate` code to also work on `LongSubSeq`, which also returns `LongAA`.
Other subtypes of `BioSequence` must implement their own version of `translate`.

This also changes how `GeneticCode` is indexed, which is technically breaking. Previously, it used an unsafe `@inbounds` index using an `UInt64`, zero-indexed. Now, it's generic over `Integer`, guarded behinds a `@boundscheck`, and one-based, as is idiomatic. I think it's unlikely someone relied on the old, unsafe behaviour.

## TODO
* ~~It would be nicer if the implementation was generic across sequence types, but I'm not sure how to do this. Perhaps we could make it so sequences of type `Seq{Alph}` creates a `Seq{AminoAcidAlphabet}`, then filled it in. This would only work for mutable sequences.~~ Nevermind, I can't do that, because subtypes of BioSequence may not be parameterized.
* This needs tests. It would be nice to refactor the translation tests now that I'm at it.

## Types of changes
* [X] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [X] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :ballot_box_with_check: Checklist

- [X] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
