### PR TITLE
Improve error when mis-encoding LongDNA from byte-like inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED]
+### Added
+* Improved error message when encoding LongDNA from byte-like objects
 
 ## [3.1.0]
 ### Added

--- a/test/longsequences/basics.jl
+++ b/test/longsequences/basics.jl
@@ -24,6 +24,15 @@
     @test LongSequence(SimpleSeq("AUCGU")) isa LongRNA{2}
     @test LongSequence(SimpleSeq("AUCGU")) == LongRNA{2}("AUCGU")
     LongDNA{4}(LongRNA{4}("AUCGUA")) == LongDNA{4}("ATCGTA")
+
+    # Displays a nice error when constructed from strings substrings
+    # and bytearrays on encoding error
+    @static if VERSION >= v"1.8"
+        malformed = "ACWpNS"
+        @test_throws "Cannot encode byte $(repr(UInt8('p'))) (char 'p') at index 4 to BioSequences.DNAAlphabet{4}" LongDNA{4}(malformed)
+        malformed = "AGCUGUAGUCGGUAUAUAGGCGCGCUCGAUGAUGAUGCGUGCUGCUATDNANCUG"
+        @test_throws "Cannot encode byte $(repr(UInt8('T'))) (char 'T') at index $(length(malformed) - 7) to BioSequences.RNAAlphabet{2}" LongRNA{2}(malformed)
+    end
 end
 
 @testset "Copy sequence" begin


### PR DESCRIPTION
This only applies to LongDNA encoded from byte-like inputs, since this uses a fast path in BioSequences, where we have access to the whole sequence. Other paths leading to the error happens from direct calls to e.g. convert(DNA, x) in BioSymbols, so the error cannot be improved much. Old error looks like: "Cannot encode 0x20 to DNAAlphabet{4}()". New error looks like: "Cannot encode byte 0x20 (char ' ') at index 3 to DNAAlphabet{4}()".

## Example:
The following file, with a `p` letter wrongly inside a DNA sequence in a FASTA file:
```julia
using BioSequences, FASTX

seqs = open(FASTAReader, "contigs.fna") do reader
    map(rec -> sequence(LongDNA{2}, rec), reader)
end
```
Throws this error:
`ERROR: LoadError: Cannot encode byte 0x70 (char 'p') at index 2170 to DNAAlphabet{2}()`

Note that the sequence identifier cannot be part of the error, since the error occurs in BioSequences, not FASTX.

If the char is unprinteable, it will look like this instead:
`ERROR: LoadError: Cannot encode byte 0xff at index 2170 to DNAAlphabet{2}()`

This change does NOT apply to generic encoding errors, only to the more common one where `LongSequence` is encoded from a String, SubString{String} or AbstractVector{UInt8}. E.g, when making a LongSequence from a vector of Char:
```
julia> LongDNA{4}(collect("apm"))
ERROR: InexactError: convert(DNA,  p)
```