### PR TITLE
Add guessparse function

### DIFF
--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -133,6 +133,7 @@ export
     ###
     ### LongSequence
     ###
+    guessparse,
 
     # Type & aliases
     LongSequence,


### PR DESCRIPTION
This function is a quick-and-dirty parser function from `AbstractString` to `LongSequence`, with autodetection of the alphabet. It's meant to be used in ephemeral REPL work, and very clearly documented to be unstable and subject to change.

See #268

This is just a draft. The implementation is straightforward, but we might want to think about whether we want this, and what it should be called.
Preferably, the name should be:
* Short, since it's meant to be used in the REPL
* Very clear in that this function is based on guesswork, and is therefore not suitable for long-lasting code.

TODO:
- [ ] Bikeshed the name and functionality
- [ ] Tests
- [ ] Update changelog
- [ ] Update docs
- [ ] More comments in the LUT table generation