### PR TITLE
Fix behavior of iterate on indices <= 0

### DIFF
--- a/src/biosequence/indexing.jl
+++ b/src/biosequence/indexing.jl
@@ -8,7 +8,7 @@
 ### License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
 @inline function Base.iterate(seq::BioSequence, i::Int = firstindex(seq))
-    i > lastindex(seq) ? nothing : @inbounds seq[i], i + 1
+    (i <= 0) || (i > lastindex(seq)) ? nothing : @inbounds seq[i], i + 1
 end
 
 ## Bounds checking

--- a/src/biosequence/indexing.jl
+++ b/src/biosequence/indexing.jl
@@ -8,7 +8,7 @@
 ### License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
 @inline function Base.iterate(seq::BioSequence, i::Int = firstindex(seq))
-    (i % UInt) - 1 < lastindex(seq) ? (@inbounds seq[i], i + 1) : nothing
+    (i % UInt) - 1 < (lastindex(seq) % UInt) ? (@inbounds seq[i], i + 1) : nothing
 end
 
 ## Bounds checking

--- a/src/biosequence/indexing.jl
+++ b/src/biosequence/indexing.jl
@@ -8,7 +8,7 @@
 ### License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
 @inline function Base.iterate(seq::BioSequence, i::Int = firstindex(seq))
-    (i <= 0) || (i > lastindex(seq)) ? nothing : @inbounds seq[i], i + 1
+    (i % UInt) - 1 < lastindex(seq) ? (@inbounds seq[i], i + 1) : nothing
 end
 
 ## Bounds checking

--- a/test/longsequences/iteration.jl
+++ b/test/longsequences/iteration.jl
@@ -10,4 +10,13 @@
     aa_seq = aa"ARNPS"
     aa_vec = [AA_A, AA_R, AA_N, AA_P, AA_S]
     @test all([aa == aa_vec[i] for (i, aa) in enumerate(aa_seq)])
+    
+    @test iterate(dna_seq) == iterate(dna_seq, 1) == (DNA_A, 2)
+    @test iterate(dna_seq, 2) == (DNA_C, 3)
+    @test iterate(dna_seq, 3) == (DNA_T, 4)
+    @test iterate(dna_seq, 4) == (DNA_G, 5)
+    
+    @test iterate(dna_seq, -1) == nothing
+    @test iterate(dna_seq, 0) == nothing
+    @test iterate(dna_seq, 5) == nothing
 end


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

This is how iterate behaves on strings
```julia
julia> x = "ATCG"
"ATCG"

julia> iterate(x)
('A', 2)

julia> iterate(x, -1)

julia> iterate(x, 0)

julia> iterate(x, 1)
('A', 2)

julia> iterate(x, 2)
('T', 3)

julia> iterate(x, 4)
('G', 5)

julia> iterate(x, 5)
```

iterate currently behaves as expected when indexing >= length(seq), but will crash when using any index less than or equal to the initial position (1)
```julia
julia> x = BioSequences.randdnaseq(3)
3nt DNA Sequence:
TGG

julia> iterate(x, 4)

julia> iterate(x, 0)

signal (11): Segmentation fault
in expression starting at REPL[5]:1
>> at ./int.jl:456 [inlined]
extract_encoded_element at /home/jovyan/workspace/BioSequences.jl/src/bit-manipulation/bitindex.jl:74 [inlined]
extract_encoded_element at /home/jovyan/workspace/BioSequences.jl/src/longsequences/indexing.jl:18 [inlined]
getindex at /home/jovyan/workspace/BioSequences.jl/src/biosequence/indexing.jl:39 [inlined]
iterate at /home/jovyan/workspace/BioSequences.jl/src/biosequence/indexing.jl:11
unknown function (ip: 0x7f5e879a9631)
```

## :ballot_box_with_check: Checklist

- [ ] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [ ] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.


## Notes

Found this while trying to fix https://github.com/BioJulia/Kmers.jl/issues/33 - I think I've got that issue fixed, but this (unrelated issue) was the next failing test that I hit in the Kmers.jl tests