### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,12 @@ version = "3.1.3"
 [deps]
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Twiddle = "7200193e-83a8-5a55-b20d-5d36d44a0795"
 
 [compat]
 BioSymbols = "5.1.2"
-SnoopPrecompile = "1"
+PrecompileTools = "1"
 StableRNGs = "0.1, 1.0"
 Twiddle = "1.1.1"
 julia = "1.5"

--- a/src/workload.jl
+++ b/src/workload.jl
@@ -1,5 +1,5 @@
 using BioSequences
-using SnoopPrecompile
+using PrecompileTools
 
 # BioSequences define a whole bunch of types and methods, most of which is never used in any workload.
 # This workload here uses what I consider to be the most common operations,
@@ -8,7 +8,7 @@ using SnoopPrecompile
 # not wasting time loading code the user will never use.
 # The code not cached here will have to be precompiled in downstream packages
 
-@precompile_all_calls begin
+@compile_workload begin
     seqs = [
         aa"TAGCW"
         dna"ATCGA"


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
