### PR TITLE
Improve heuristics of translating ambiguous nucs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,28 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED]
-### Added
-* Improved error message when encoding LongDNA from byte-like objects
+
+## [3.1.6]
+* The heuristics for translating sequences with ambiguous symbols is now improved.
+  Now, `translate` does not rely on heuristics but uses an algorithm that always
+  returns exactly the right amino acid in the face of ambiguous nucleotides.
+
+## [3.1.5]
+* Attempting to translate a nucleotide sequence with gap symbols now throws an error (#278, see #277)
+
+## [3.1.4]
+* Migrate from SnoopPrecompile to PrecompileTools (#273)
+
+## [3.1.3]
+* Improve error when mis-encoding `LongDNA` from byte-like inputs (#267)
+* Remove references to internal `Random.GLOBAL_RNG` (#265)
+
+## [3.1.2]
+* Fix bug in converting `LongSubSeq` to `LongSequence` (#261)
+
+## [3.1.1]
+* Add `iterate` method for `Alphabets` (#233)
+* Add SnoopPrecompile workload and dependency on SnoopPrecompile (#257)
 
 ## [3.1.0]
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BioSequences"
 uuid = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 authors = ["Sabrina Jaye Ward <sabrinajward@protonmail.com>", "Jakob Nissen <jakobnybonissen@gmail.com>"]
-version = "3.1.5"
+version = "3.1.6"
 
 [deps]
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"

--- a/test/translation.jl
+++ b/test/translation.jl
@@ -60,6 +60,8 @@
     # ambiguous codons
     @test translate(rna"YUGMGG") == aa"LR"
     @test translate(rna"GAYGARGAM") == aa"DEX"
+    @test translate(rna"MUCGGG") == aa"JG"
+    @test translate(rna"AAASAAUUU") == aa"KZF"
 
     # BioSequences{RNAAlphabet{2}}
     @test translate(LongSequence{RNAAlphabet{2}}("AAAUUUGGGCCC")) == translate(rna"AAAUUUGGGCCC")


### PR DESCRIPTION
Use a more principled approach, such that we now guarantee that ambiguous DNA
and RNA is translated to exactly the set of amino acids the genetic code
corresponds to.