### PR TITLE
Remove downstream BioMakie CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -30,7 +30,6 @@ jobs:
           - {user: BioJulia, repo: XAM.jl, group: BioSequences}
           - {user: crsl4, repo: PhyloNetworks.jl, group: BioSequences}
           - {user: JuliaHealth, repo: CAOS.jl, group: BioSequences}
-          - {user: kool7d, repo: BioMakie.jl, group: BioSequences}
           - {user: nguyetdang, repo: BioGraph.jl, group: BioSequences}
           - {user: vanOosterhoutLab, repo: SpeedDate.jl, group: BioSequences}
           - {user: varnerlab, repo: JUGRNModelGenerator.jl, group: BioSequences}


### PR DESCRIPTION
This has been consistently broken ever since it was introduced. Also, the tests take like 20 minutes before they fail, single-handedly multiplying BioSequences CI time by like 4.
