### PR TITLE
Define compat for Random

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Twiddle = "7200193e-83a8-5a55-b20d-5d36d44a0795"
 [compat]
 BioSymbols = "5.1.2"
 PrecompileTools = "1"
+Random = "1.5"
 StableRNGs = "0.1, 1.0"
 Twiddle = "1.1.1"
 julia = "1.5"


### PR DESCRIPTION
This was not needed previously as the version of Random was tied to the version of Julia, but in upcoming Julia versions, Random will be versioned separately. This change makes BioSequences.jl compatible with future versions of Julia.