### PR TITLE
Drop CI for MacOS Julia 1.5

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -12,16 +12,19 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.5' # Minimally supported version of Julia
+          - '1.5' # Minimally supported version of Julia.
           - '1'
         julia-arch: [x86]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
         experimental: [false]
         include:
           - julia-version: nightly
             julia-arch: x86
             os: ubuntu-latest
             experimental: true
+          - julia-version: 1
+            os: macOS-latest
+            experimental: false
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
The latest MacOS is not compatible with x86 processors, and Julia 1.5 is only compatible with x86. We could test on older versions of MacOS, but why bother.
