### PR TITLE
Drop pre-LTS Julia support

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -19,21 +19,16 @@ jobs:
         package:
           - {user: bioinfologics, repo: Pseudoseq.jl, group: BioSequences}
           - {user: BioJulia, repo: BioAlignments.jl, group: BioSequences}
-          - {user: BioJulia, repo: BioStructures.jl, group: BioSequences}
           - {user: BioJulia, repo: FASTX.jl, group: BioSequences}
           - {user: BioJulia, repo: GenomeGraphs.jl, group: BioSequences}
-          - {user: BioJulia, repo: GenomicAnnotations.jl, group: BioSequences}
           - {user: BioJulia, repo: GFF3.jl, group: BioSequences}
           - {user: BioJulia, repo: KmerAnalysis.jl, group: BioSequences}
           - {user: BioJulia, repo: ReadDatastores.jl, group: BioSequences}
           - {user: BioJulia, repo: TwoBit.jl, group: BioSequences}
           - {user: BioJulia, repo: XAM.jl, group: BioSequences}
-          - {user: crsl4, repo: PhyloNetworks.jl, group: BioSequences}
           - {user: JuliaHealth, repo: CAOS.jl, group: BioSequences}
           - {user: nguyetdang, repo: BioGraph.jl, group: BioSequences}
           - {user: vanOosterhoutLab, repo: SpeedDate.jl, group: BioSequences}
-          - {user: varnerlab, repo: JUGRNModelGenerator.jl, group: BioSequences}
-          - {user: varnerlab, repo: VLConstraintBasedModelGenerationUtilities.jl, group: BioSequences}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -11,8 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version:
-          - '1'
+        julia-version: ['1', '1.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         experimental: [false]
         include:
@@ -22,19 +21,6 @@ jobs:
             os: ubuntu-latest
             experimental: true
             fail_ci_if_error: false
-          # Windows is extremely slow on 1.6, so we skip this combination,
-          # since it increases CI time by 5x
-          - julia-version: '1.7'
-            os: windows-latest
-            experimental: false
-          # Oldest supported version
-          - julia-version: '1.5'
-            os: ubuntu-latest
-            experimental: false
-          # MacOS Aarch64 reached Tier1 support of Julia in version 1.9
-          - julia-version: '1.9'
-            os: macOS-latest
-            experimental: false
 
     steps:
       - name: Checkout Repository

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ PrecompileTools = "1"
 Random = "1.5"
 StableRNGs = "0.1, 1.0"
 Twiddle = "1.1.1"
-julia = "1.5"
+julia = "1.10"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"


### PR DESCRIPTION
This allows us to simplify CI, since we can run the oldest supported Julia version on aarch64 macos, and also allows us to mark const field const.

