### PR TITLE
More consistently throw EncodeError

### DIFF
--- a/src/alphabet.jl
+++ b/src/alphabet.jl
@@ -79,14 +79,31 @@ iscomplete(A::Alphabet) = Val(length(symbols(A)) === 1 << bits_per_symbol(A))
 ## Encoders & Decoders
 
 """
-    encode(::Alphabet, x::S)
+    encode(::Alphabet, s::BioSymbol)
 
-
-Encode BioSymbol `S` to an internal representation using an `Alphabet`.
+Internal function, do not use in user code.
+Encode BioSymbol `s` to an internal representation using an [`Alphabet`](@ref).
 This decoding is checked to enforce valid data element.
-"""
-function encode end
+If `s` cannot be encoded to the given alphabet, throw an `EncodeError`
 
+"""
+encode(A::Alphabet, s::BioSymbol) = throw(EncodeError(A, s))
+
+"""
+    EncodeError
+
+Exception thrown when a `BioSymbol` cannot be encoded to a given [`Alphabet`](@ref).
+
+# Examples
+```
+julia> try
+           BioSequences.encode(DNAAlphabet{2}(), DNA_N)
+       catch err
+           println(err isa BioSequences.EncodeError)
+       end
+true
+```
+"""
 struct EncodeError{A<:Alphabet,T} <: Exception
     val::T
 end

--- a/test/alphabet.jl
+++ b/test/alphabet.jl
@@ -48,6 +48,16 @@ encode = BioSequences.encode
 EncodeError = BioSequences.EncodeError
 decode = BioSequences.decode
 
+@testset "EncodeError" begin
+    @test_throws EncodeError encode(DNAAlphabet{4}(), RNA_U)
+    @test_throws EncodeError encode(DNAAlphabet{2}(), DNA_M)
+    @test_throws EncodeError encode(DNAAlphabet{4}(), AA_C)
+    @test_throws EncodeError encode(AminoAcidAlphabet(), DNA_C)
+    @test_throws EncodeError encode(AminoAcidAlphabet(), RNA_N)
+    @test_throws EncodeError encode(RNAAlphabet{2}(), DNA_C)
+    @test_throws EncodeError encode(RNAAlphabet{2}(), RNA_K)
+end
+
 # NOTE: See the docs for the interface of Alphabet
 struct ReducedAAAlphabet <: Alphabet end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using Documenter
 using Random
 using StableRNGs
 using LinearAlgebra: normalize
-import BioSymbols
+using BioSymbols
 using BioSequences
 using StatsBase
 using YAML


### PR DESCRIPTION
Add a fallback method to `encode`, such that encoding into an incompatible alphabet will more consistently throw EncodeError. This will help users catch these errors.