### PR TITLE
Speed up search operations for SeqOrView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ docs/site/
 Manifest.toml
 
 .DS_Store
+
+LocalPreferences.toml
+
+TODO.md

--- a/src/alphabet.jl
+++ b/src/alphabet.jl
@@ -102,7 +102,7 @@ If `s` cannot be encoded to the given alphabet, throw an `EncodeError`
     return y === nothing ? throw(EncodeError(A, s)) : y
 end
 
-tryencode(A::Alphabet, s::BioSymbol) = throw(EncodeError(A, s))
+tryencode(A::Alphabet, s::BioSymbol) = nothing
 
 """
     tryencode(::Alphabet, x::S)
@@ -387,3 +387,5 @@ function guess_alphabet(v::AbstractVector{UInt8})
     end
 end
 guess_alphabet(s::AbstractString) = guess_alphabet(codeunits(s))
+
+const KNOWN_ALPHABETS = Union{DNAAlphabet, RNAAlphabet, AminoAcidAlphabet}

--- a/src/alphabet.jl
+++ b/src/alphabet.jl
@@ -102,7 +102,7 @@ If `s` cannot be encoded to the given alphabet, throw an `EncodeError`
     return y === nothing ? throw(EncodeError(A, s)) : y
 end
 
-tryencode(A::Alphabet, s::BioSymbol) = nothing
+tryencode(A::Alphabet, s::Any) = nothing
 
 """
     tryencode(::Alphabet, x::S)

--- a/src/biosequence/find.jl
+++ b/src/biosequence/find.jl
@@ -37,18 +37,18 @@ Base.findlast(f::Function, seq::BioSequence) = findprev(f, seq, lastindex(seq))
 
 # Finding specific symbols
 
-Base.findnext(x::DNA, seq::BioSequence{<:DNAAlphabet}, start::Integer) = Base.findnext(isequal(x), seq, start)
-Base.findnext(x::RNA, seq::BioSequence{<:RNAAlphabet}, start::Integer) = Base.findnext(isequal(x), seq, start)
-Base.findnext(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}, start::Integer) = Base.findnext(isequal(x), seq, start)
+Base.findnext(x::DNA, seq::BioSequence{<:DNAAlphabet}, start::Integer) = findnext(isequal(x), seq, start)
+Base.findnext(x::RNA, seq::BioSequence{<:RNAAlphabet}, start::Integer) = findnext(isequal(x), seq, start)
+Base.findnext(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}, start::Integer) = findnext(isequal(x), seq, start)
 
-Base.findprev(x::DNA, seq::BioSequence{<:DNAAlphabet}, start::Integer) = Base.findprev(isequal(x), seq, start)
-Base.findprev(x::RNA, seq::BioSequence{<:RNAAlphabet}, start::Integer) = Base.findprev(isequal(x), seq, start)
-Base.findprev(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}, start::Integer) = Base.findprev(isequal(x), seq, start)
+Base.findprev(x::DNA, seq::BioSequence{<:DNAAlphabet}, start::Integer) = findprev(isequal(x), seq, start)
+Base.findprev(x::RNA, seq::BioSequence{<:RNAAlphabet}, start::Integer) = findprev(isequal(x), seq, start)
+Base.findprev(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}, start::Integer) = findprev(isequal(x), seq, start)
 
-Base.findfirst(x::DNA, seq::BioSequence{<:DNAAlphabet}) = Base.findfirst(isequal(x), seq)
-Base.findfirst(x::RNA, seq::BioSequence{<:RNAAlphabet}) = Base.findfirst(isequal(x), seq)
-Base.findfirst(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}) = Base.findfirst(isequal(x), seq)
+Base.findfirst(x::DNA, seq::BioSequence{<:DNAAlphabet}) = findfirst(isequal(x), seq)
+Base.findfirst(x::RNA, seq::BioSequence{<:RNAAlphabet}) = findfirst(isequal(x), seq)
+Base.findfirst(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}) = findfirst(isequal(x), seq)
 
-Base.findlast(x::DNA, seq::BioSequence{<:DNAAlphabet}) = Base.findlast(isequal(x), seq)
-Base.findlast(x::RNA, seq::BioSequence{<:RNAAlphabet}) = Base.findlast(isequal(x), seq)
-Base.findlast(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}) = Base.findlast(isequal(x), seq)
+Base.findlast(x::DNA, seq::BioSequence{<:DNAAlphabet}) = findlast(isequal(x), seq)
+Base.findlast(x::RNA, seq::BioSequence{<:RNAAlphabet}) = findlast(isequal(x), seq)
+Base.findlast(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}) = findlast(isequal(x), seq)

--- a/src/counting.jl
+++ b/src/counting.jl
@@ -3,8 +3,6 @@
 # Instead, we could emit the head and tail chunk seperately, then an iterator of
 # all the full chunks loaded as single elements from the underlying vector.
 
-const KNOWN_ALPHABETS = Union{DNAAlphabet, RNAAlphabet, AminoAcidAlphabet}
-
 trunc_seq(x::LongSequence, len::Int) = typeof(x)(x.data, len % UInt)
 trunc_seq(x::LongSubSeq, len::Int) = typeof(x)(x.data, first(x.part):first(x.part)+len-1)
 

--- a/src/longsequences/chunk_iterator.jl
+++ b/src/longsequences/chunk_iterator.jl
@@ -161,7 +161,7 @@ function parts(seq::LongSequence)
     end
     # If we have bits in the tail, then clearly those bits means the last bitindex
     # points to one past the last full chunk
-    body = (1, lbii - !iszero(bits_in_tail))
+    body = (UInt(1), (lbii - !iszero(bits_in_tail)) % UInt)
     (head, body, tail)
 end
 

--- a/src/longsequences/chunk_iterator.jl
+++ b/src/longsequences/chunk_iterator.jl
@@ -130,3 +130,78 @@ Base.eltype(::Type{<:PairedChunkIterator}) = NTuple{2, UInt64}
     b = iter_inbounds(it.b, last(state))
     ((first(a), first(b)), (last(a), last(b)))
 end
+
+# This returns (head, body, tail), where:
+# - head and tail are Tuple{UInt64, UInt8}, with a coding element and the number
+#   of coding bits in that element. Head is the partial coding element before any
+#   full elements, and tail is the partial after any coding elements.
+#   If head or tail is empty, the UInt8 is set to zero. By definition, it can be
+#   at most set to 63.
+#   If the sequence is composed of only one partial element, tail is nonempty
+#   and head is empty.
+# - body is a Tuple{UInt, UInt} with the (start, stop) indices of coding elements.
+#   If stop < start, there are no such elements.
+# TODO: The body should probably be a MemoryView in 1.11
+function parts(seq::LongSequence)
+    # LongSequence never has coding bits before the first chunks
+    head = (zero(UInt64), zero(UInt8))
+    len = length(seq)
+    # Shortcut to prevent annoying edge cases in the rest of the code
+    if iszero(len)
+        return (head, (UInt(1), UInt(0)), (zero(UInt64), zero(UInt8)))
+    end
+    lastbitindex(seq)
+    bits_in_tail = (offset(bitindex(seq, len + 1)) % UInt8) & 0x3f
+    lbi = bitindex(seq, len)
+    lbii = index(lbi)
+    tail = if iszero(bits_in_tail)
+        head
+    else
+        (@inbounds(seq.data[lbii]), bits_in_tail)
+    end
+    # If we have bits in the tail, then clearly those bits means the last bitindex
+    # points to one past the last full chunk
+    body = (1, lbii - !iszero(bits_in_tail))
+    (head, body, tail)
+end
+
+function parts(seq::LongSubSeq)
+    data = seq.data
+    zero_end = (zero(UInt64), zero(UInt8))
+    len = length(seq)
+    # Again: Avoid annoying edge cases later
+    if iszero(len)
+        return (zero_end, (UInt(1), UInt(0)), zero_end)
+    end
+    lastbitindex(seq)
+    lbi = bitindex(seq, len)
+    lbii = index(lbi)
+    fbi = firstbitindex(seq)
+    fbii = index(fbi)
+    bits_in_head_naive = (((64 - offset(fbi)) % UInt8) & 0x3f)
+    # If first and last chunk index is the same, there are actually zero
+    # bits in head, as they are all in the tail
+    bits_in_head = bits_in_head_naive * (lbii != fbii)
+    # For the head, there are some uncoding lower bits. We need to shift
+    # the head right with this number.
+    head_shift = ((0x40 - bits_in_head_naive) & 0x3f)
+    head = if iszero(bits_in_head)
+        zero_end
+    else
+        chunk = @inbounds(data[fbii]) >> head_shift
+        (chunk, bits_in_head)
+    end
+    # However, if last and first chunk index is the same, there is no head
+    # chunk, and thus no head chunk to shift, but the TAIL chunk may not have coding bits at the lowest
+    # position.
+    tail_shift = (head_shift * (lbii == fbii)) & 63
+    bits_in_tail = (offset(bitindex(seq, len + 1)) % UInt8) & 0x3f
+    bits_in_tail -= tail_shift % UInt8
+    tail = if iszero(bits_in_tail)
+        zero_end
+    else
+        (@inbounds(data[lbii]) >> tail_shift, bits_in_tail)
+    end
+    body = (fbii + !iszero(bits_in_head), lbii - !iszero(bits_in_tail))
+    (head, body, tail)
+end

--- a/src/longsequences/seqview.jl
+++ b/src/longsequences/seqview.jl
@@ -52,25 +52,25 @@ function LongSubSeq{A}(seq::LongSubSeq{A}) where A
     return LongSubSeq{A}(seq.data, seq.part)
 end
 
-function LongSubSeq{A}(seq::LongSequence{A}, part::AbstractUnitRange{<:Integer}) where A
+Base.@propagate_inbounds function LongSubSeq{A}(seq::LongSequence{A}, part::AbstractUnitRange{<:Integer}) where A
     @boundscheck checkbounds(seq, part)
     return LongSubSeq{A}(seq.data, UnitRange{Int}(part))
 end
 
-function LongSubSeq{A}(seq::LongSubSeq{A}, part::AbstractUnitRange{<:Integer}) where A
+Base.@propagate_inbounds function LongSubSeq{A}(seq::LongSubSeq{A}, part::AbstractUnitRange{<:Integer}) where A
     @boundscheck checkbounds(seq, part)
     newpart = first(part) + first(seq.part) - 1 : last(part) + first(seq.part) - 1
     return LongSubSeq{A}(seq.data, newpart)
 end
 
-function LongSubSeq(seq::SeqOrView{A}, i) where A
+Base.@propagate_inbounds function LongSubSeq(seq::SeqOrView{A}, i) where A
 	return LongSubSeq{A}(seq, i)
 end
 
-LongSubSeq(seq::SeqOrView, ::Colon) = LongSubSeq(seq, 1:lastindex(seq))
-LongSubSeq(seq::BioSequence{A}) where A = LongSubSeq{A}(seq)
+Base.@propagate_inbounds LongSubSeq(seq::SeqOrView, ::Colon) = LongSubSeq(seq, 1:lastindex(seq))
+Base.@propagate_inbounds LongSubSeq(seq::BioSequence{A}) where A = LongSubSeq{A}(seq)
 
-Base.view(seq::SeqOrView, part::AbstractUnitRange) = LongSubSeq(seq, part)
+Base.@propagate_inbounds Base.view(seq::SeqOrView, part::AbstractUnitRange) = LongSubSeq(seq, part)
 
 function (::Type{T})(seq::SeqOrView{<:NucleicAcidAlphabet{2}}) where
          {T<:LongSequence{<:NucleicAcidAlphabet{4}}}
@@ -145,7 +145,7 @@ function (::Type{T})(seq::LongSequence{<:NucleicAcidAlphabet{N}}) where
 	T(seq.data, 1:length(seq))
 end
 
-function (::Type{T})(seq::LongSequence{<:NucleicAcidAlphabet{N}}, part::AbstractUnitRange{<:Integer}) where
+Base.@propagate_inbounds function (::Type{T})(seq::LongSequence{<:NucleicAcidAlphabet{N}}, part::AbstractUnitRange{<:Integer}) where
 	{N, T<:LongSubSeq{<:NucleicAcidAlphabet{N}}}
 	@boundscheck checkbounds(seq, part)
 	T(seq.data, UnitRange{Int}(part))

--- a/test/alphabet.jl
+++ b/test/alphabet.jl
@@ -129,7 +129,7 @@ end
         @test tryencode(DNAAlphabet{2}(), DNA_M) === nothing
         @test tryencode(DNAAlphabet{2}(), DNA_N) === nothing
         @test tryencode(DNAAlphabet{2}(), DNA_Gap) === nothing
-        @test_throws EncodeError tryencode(DNAAlphabet{2}(), RNA_G)
+        @test tryencode(DNAAlphabet{2}(), RNA_G) === nothing
 
         # 4 bits
         for nt in BioSymbols.alphabet(DNA)
@@ -154,7 +154,7 @@ end
         @test tryencode(RNAAlphabet{2}(), RNA_M) === nothing
         @test tryencode(RNAAlphabet{2}(), RNA_N) === nothing
         @test tryencode(RNAAlphabet{2}(), RNA_Gap) === nothing
-        @test_throws EncodeError tryencode(RNAAlphabet{2}(), DNA_G)
+        @test tryencode(RNAAlphabet{2}(), DNA_G) === nothing
 
         # 4 bits
         for nt in BioSymbols.alphabet(RNA)

--- a/test/longsequences/find.jl
+++ b/test/longsequences/find.jl
@@ -1,3 +1,11 @@
+# Some examples
+
+# Before 1, after lastindex
+
+# Cannot encode
+
+# Views
+
 @testset "Find" begin
     seq = dna"ACGNA"
     @test findnext(isequal(DNA_A), seq, 1) == 1
@@ -7,7 +15,7 @@
     @test findnext(isequal(DNA_T), seq, 1) === nothing
     @test findnext(isequal(DNA_A), seq, 2) == 5
 
-    @test_throws BoundsError findnext(isequal(DNA_A), seq, 0)
+    #@test_throws BoundsError findnext(isequal(DNA_A), seq, 0)
     @test findnext(isequal(DNA_A), seq, 6) === nothing
 
     @test findprev(isequal(DNA_A), seq, 4) == 1
@@ -18,7 +26,7 @@
     @test findprev(isequal(DNA_G), seq, 2) === nothing
 
     @test findprev(isequal(DNA_A), seq, 0) === nothing
-    @test_throws BoundsError findprev(isequal(DNA_A), seq, 6)
+    #findprev(isequal(DNA_A), seq, 6)
 
     seq = dna"ACGNAN"
     @test findfirst(isequal(DNA_A), seq) == 1

--- a/test/longsequences/find.jl
+++ b/test/longsequences/find.jl
@@ -1,43 +1,74 @@
-# Some examples
-
-# Before 1, after lastindex
-
-# Cannot encode
-
-# Views
-
 @testset "Find" begin
-    seq = dna"ACGNA"
-    @test findnext(isequal(DNA_A), seq, 1) == 1
-    @test findnext(isequal(DNA_C), seq, 1) == 2
-    @test findnext(isequal(DNA_G), seq, 1) == 3
-    @test findnext(isequal(DNA_N), seq, 1) == 4
-    @test findnext(isequal(DNA_T), seq, 1) === nothing
-    @test findnext(isequal(DNA_A), seq, 2) == 5
+    seq = dna"TACT-WKKATYACCG"
 
-    #@test_throws BoundsError findnext(isequal(DNA_A), seq, 0)
-    @test findnext(isequal(DNA_A), seq, 6) === nothing
+    @test findfirst(==(DNA_T), seq) == 1
+    @test findfirst(==(DNA_A), seq) == 2
+    @test findfirst(isequal(DNA_C), seq) == 3
+    @test findfirst(==(DNA_Gap), seq) == 5
+    @test findfirst(isequal(DNA_W), seq) == 6
+    @test findfirst(==(DNA_Y), seq) == 11
+    @test findfirst(==(DNA_G), seq) == 15
+    @test findfirst(==(DNA_M), seq) === nothing
+    @test findfirst(==(RNA_A), seq) === nothing
+    @test findfirst(==(AA_W), seq) === nothing
+    @test findfirst(==('C'), seq) === nothing
 
-    @test findprev(isequal(DNA_A), seq, 4) == 1
-    @test findprev(isequal(DNA_C), seq, 4) == 2
-    @test findprev(isequal(DNA_G), seq, 4) == 3
-    @test findprev(isequal(DNA_N), seq, 4) == 4
-    @test findprev(isequal(DNA_T), seq, 4) === nothing
-    @test findprev(isequal(DNA_G), seq, 2) === nothing
+    @test findlast(isequal(DNA_C), seq) == 14
+    @test findlast(isequal(DNA_G), seq) == 15
+    @test findlast(isequal(DNA_Y), seq) == 11
+    @test findlast(isequal(DNA_W), seq) == 6
+    @test findlast(isequal(RNA_Y), seq) === nothing
+    @test findlast(isequal(RNA_Gap), seq) === nothing
 
-    @test findprev(isequal(DNA_A), seq, 0) === nothing
-    #findprev(isequal(DNA_A), seq, 6)
+    #               1   5    10   15   20
+    seq = view(aa"WKRRLY-JNMOPQALKAVWYOPQRT", 3:22)
+    @test findnext(==(AA_R), seq, 1) == 1
+    @test findnext(==(AA_R), seq, 3) === nothing
+    @test findnext(==(AA_J), seq, 6) == 6
+    @test findnext(==(AA_J), seq, 7) === nothing
+    @test findnext(==(AA_Q), seq, 5) == 11
+    @test findnext(==(AA_V), seq, 1) == 16
+    @test findnext(==(AA_Y), seq, 4) == 4
+    @test findnext(==(AA_Y), seq, 5) == 18
+    @test findnext(==(DNA_M), seq, 1) === nothing
+    @test findnext(==(RNA_A), seq, 1) === nothing
+    @test findnext(==(AA_C), seq, 1) === nothing
+    @test findnext(==(19), seq, 1) === nothing
 
-    seq = dna"ACGNAN"
-    @test findfirst(isequal(DNA_A), seq) == 1
-    @test findfirst(isequal(DNA_N), seq) == 4
-    @test findfirst(isequal(DNA_T), seq) === nothing
+    # View with head and chunk only
+    #                        1   5    10   15   20 
+    seq = view(dna"TAGTCKYDDBN--ACGKMYAGCTATAYYKKM-", 11:32)
+    @test findnext(==(DNA_Gap), seq, 1) == 2
+    @test findnext(==(DNA_C), seq, 2) == 5
+    @test findnext(==(DNA_Y), seq, 2) == 9
+    @test findnext(==(DNA_Y), seq, 7) == 9
+    @test findnext(==(DNA_M), seq, 8) == 8
+    @test findnext(==(DNA_M), seq, 9) == 21
 
-    @test findlast(isequal(DNA_A), seq) == 5
-    @test findlast(isequal(DNA_N), seq) == 6
-    @test findlast(isequal(DNA_T), seq) === nothing
+    # View with only tail
+    #               1234
+    seq = view(aa"KWYPAV-L", 3:6)
+    @test findnext(==(AA_K), seq, 1) === nothing
+    @test findnext(==(AA_Y), seq, 1) == 1
+    @test findnext(==(AA_V), seq, 2) == 4
+    @test findnext(==(AA_A), seq, 3) == 3
+    @test findnext(==(AA_A), seq, 4) === nothing
+    @test findnext(==(RNA_Y), seq, 1) === nothing
 
+    @test findprev(==(AA_K), seq, 4) === nothing
+    @test findprev(==(AA_P), seq, 3) == 2
+    @test findprev(==(AA_A), seq, 2) === nothing
+    @test findprev(==(AA_Y), seq, 4) == 1
 
+    # Empty view
+    seq = view(dna"ATCGGACTGTAGTATGAACGGATATATGCTTATAATG", 19:18)
+    for i in [DNA_A, DNA_C, DNA_G, DNA_T, DNA_Gap]
+        @test findfirst(==(i), seq) === nothing
+        @test findlast(==(i), seq) === nothing
+    end
+end
+
+@testset "Search" begin
     #         0000000001111
     #         1234567890123
     seq = dna"NNNNNGATCGATC"

--- a/test/longsequences/find.jl
+++ b/test/longsequences/find.jl
@@ -35,6 +35,25 @@
     @test findnext(==(AA_C), seq, 1) === nothing
     @test findnext(==(19), seq, 1) === nothing
 
+    @test findprev(==(AA_R), seq, 20) == 2
+    @test findprev(==(AA_K), seq, 15) == 14
+    @test findprev(==(AA_Y), seq, 20) == 18
+    @test findprev(==(AA_Y), seq, 17) == 4
+    @test findlast(==(AA_Q), seq) == 11
+    @test findprev(==(AA_J), seq, 16) == 6
+    @test findprev(==(AA_Gap), seq, 9) == 5
+    @test findprev(==(AA_O), seq, 3) === nothing
+    @test findprev(==(AA_L), seq, 2) === nothing
+    @test findprev(==(AA_H), seq, 17) === nothing
+
+    seq = LongRNA{2}(rna"UAGUCGUAGC")
+    @test findfirst(==(RNA_U), seq) == 1
+    @test findfirst(==(RNA_A), seq) == 2
+    @test findfirst(==(RNA_G), seq) == 3
+    @test findfirst(==(RNA_C), seq) == 5
+    @test findfirst(==(RNA_Gap), seq) === nothing
+    @test findlast(==(RNA_G), seq) == 9
+
     # View with head and chunk only
     #                        1   5    10   15   20 
     seq = view(dna"TAGTCKYDDBN--ACGKMYAGCTATAYYKKM-", 11:32)


### PR DESCRIPTION
This commit adds new methods for findnext and findprev for SeqOrView with known alphabets, which use bitparallel operations. This in turns speeds up most search ops which are defined in terms of these.
The new code is 4-20 times faster depending on circumstances.

It's only implemented for known alphabets because new alphabets may overload == in surprising ways, which makes the bitparallel ops invalid.

The commit also introduces a new internal abstraction, the `parts` function, which may be useful for other operations down the line. It's similar to the existing chunk iterators, but may be more efficient for subsequences, and can be reversed.

There is also some minor cleanup that could have been its own PR, but whatever.

## TODO
- [x] Tests
