### PR TITLE
Add more optimised find methods for BioSequences

### DIFF
--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -219,6 +219,7 @@ include("biosequence/biosequence.jl")
 include("longsequences/longsequence.jl")
 include("longsequences/hash.jl")
 include("longsequences/randseq.jl")
+include("longsequences/find.jl")
 
 include("counting.jl")
 

--- a/src/biosequence/find.jl
+++ b/src/biosequence/find.jl
@@ -46,12 +46,16 @@ end
 # N.B: The isgap and isambiguous have identical definitions but are separate methods to avoid
 # ambiguity errors.
 _findnext(::typeof(isambiguous), ::BioSequence{<:NucleicAcidAlphabet{2}}, ::Int) = nothing
-_findnext(::typeof(isgap), ::BioSequence{<:NucleicAcidAlphabet{2}}, ::Int) = nothing
 _findprev(::typeof(isambiguous), ::BioSequence{<:NucleicAcidAlphabet{2}}, ::Int) = nothing
+_findnext(::typeof(isgap), ::BioSequence{<:NucleicAcidAlphabet{2}}, ::Int) = nothing
 _findprev(::typeof(isgap), ::BioSequence{<:NucleicAcidAlphabet{2}}, ::Int) = nothing
 
 _findnext(::typeof(iscertain), seq::BioSequence{<:NucleicAcidAlphabet{2}}, from::Int) = from
 _findprev(::typeof(iscertain), seq::BioSequence{<:NucleicAcidAlphabet{2}}, from::Int) = from
+_findnext(::typeof(!isambiguous), seq::BioSequence{<:NucleicAcidAlphabet{2}}, from::Int) = from
+_findprev(::typeof(!isambiguous), seq::BioSequence{<:NucleicAcidAlphabet{2}}, from::Int) = from
+_findnext(::typeof(!isgap), seq::BioSequence{<:NucleicAcidAlphabet{2}}, from::Int) = from
+_findprev(::typeof(!isgap), seq::BioSequence{<:NucleicAcidAlphabet{2}}, from::Int) = from
 
 # Finding specific symbols
 Base.findnext(x::DNA, seq::BioSequence{<:DNAAlphabet}, start::Integer) = findnext(isequal(x), seq, start)

--- a/src/biosequence/find.jl
+++ b/src/biosequence/find.jl
@@ -7,9 +7,22 @@
 ### This file is a part of BioJulia.
 ### License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
+Base.findfirst(f::Function, seq::BioSequence) = findnext(f, seq, firstindex(seq))
+Base.findlast(f::Function, seq::BioSequence) = findprev(f, seq, lastindex(seq))
+
 function Base.findnext(f::Function, seq::BioSequence, start::Integer)
-    start > lastindex(seq) && return nothing
-    checkbounds(seq, start)
+    start = Int(start)::Int
+    @boundscheck (start < 1 && throw(BoundsError(seq, start)))
+    @inline _findnext(f, seq, start)
+end
+
+function Base.findprev(f::Function, seq::BioSequence, start::Integer)
+    start = Int(start)::Int
+    @boundscheck (start > lastindex(seq) && throw(BoundsError(seq, start)))
+    @inline _findprev(f, seq, start)
+end
+
+function _findnext(f::Function, seq::BioSequence, start::Int)
     @inbounds for i in start:lastindex(seq)
         if f(seq[i])
             return i
@@ -18,13 +31,8 @@ function Base.findnext(f::Function, seq::BioSequence, start::Integer)
     return nothing
 end
 
-# No ambiguous sites can exist in a nucleic acid sequence using the two-bit alphabet.
-Base.findnext(::typeof(isambiguous), seq::BioSequence{<:NucleicAcidAlphabet{2}}, from::Integer) = nothing
-
-function Base.findprev(f::Function, seq::BioSequence, start::Integer)
-    start < firstindex(seq) && return nothing
-    checkbounds(seq, start)
-    for i in start:-1:firstindex(seq)
+function _findprev(f::Function, seq::BioSequence, start::Int)
+    @inbounds for i in start:-1:firstindex(seq)
         if f(seq[i])
             return i
         end
@@ -32,11 +40,23 @@ function Base.findprev(f::Function, seq::BioSequence, start::Integer)
     return nothing
 end
 
-Base.findfirst(f::Function, seq::BioSequence) = findnext(f, seq, firstindex(seq))
-Base.findlast(f::Function, seq::BioSequence) = findprev(f, seq, lastindex(seq))
+# For two-bit alphabet
+# N.B: The isgap and isambiguous have identical definitions but are separate methods to avoid
+# ambiguity errors.
+_findnext(::typeof(isambiguous), ::BioSequence{<:NucleicAcidAlphabet{2}}, ::Int) = nothing
+_findnext(::typeof(isgap), ::BioSequence{<:NucleicAcidAlphabet{2}}, ::Int) = nothing
+_findprev(::typeof(isambiguous), ::BioSequence{<:NucleicAcidAlphabet{2}}, ::Int) = nothing
+_findprev(::typeof(isgap), ::BioSequence{<:NucleicAcidAlphabet{2}}, ::Int) = nothing
+
+function _findnext(::typeof(iscertain), seq::BioSequence{<:NucleicAcidAlphabet{2}}, from::Int)
+    from ≤ lastindex(seq) ? from : nothing
+end
+
+function _findprev(::typeof(iscertain), seq::BioSequence{<:NucleicAcidAlphabet{2}}, from::Int)
+    from ≥ 1 ? from : nothing
+end
 
 # Finding specific symbols
-
 Base.findnext(x::DNA, seq::BioSequence{<:DNAAlphabet}, start::Integer) = findnext(isequal(x), seq, start)
 Base.findnext(x::RNA, seq::BioSequence{<:RNAAlphabet}, start::Integer) = findnext(isequal(x), seq, start)
 Base.findnext(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}, start::Integer) = findnext(isequal(x), seq, start)
@@ -52,3 +72,7 @@ Base.findfirst(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}) = findfirst(is
 Base.findlast(x::DNA, seq::BioSequence{<:DNAAlphabet}) = findlast(isequal(x), seq)
 Base.findlast(x::RNA, seq::BioSequence{<:RNAAlphabet}) = findlast(isequal(x), seq)
 Base.findlast(x::AminoAcid, seq::BioSequence{AminoAcidAlphabet}) = findlast(isequal(x), seq)
+
+# Finding gaps
+_findnext(::typeof(isgap), seq::BioSequence, i::Int) = _findnext(==(gap(eltype(seq))), seq, i)
+_findprev(::typeof(isgap), seq::BioSequence, i::Int) = _findprev(==(gap(eltype(seq))), seq, i)

--- a/src/counting.jl
+++ b/src/counting.jl
@@ -259,12 +259,6 @@ _n_certain(seq::BioSequence) = count_naive(iscertain, seq)
 
 _n_gc(seq::BioSequence) = count_naive(isGC, seq)
 
-const FourBit = SeqOrView{<:NucleicAcidAlphabet{4}}
-const TwoBit = SeqOrView{<:NucleicAcidAlphabet{2}}
-
-const TwoBitSeq = BioSequence{<:NucleicAcidAlphabet{2}}
-const FourBitSeq = BioSequence{<:NucleicAcidAlphabet{4}}
-
 # Trivial overloads
 _n_certain(s::TwoBitSeq) = length(s)
 _n_ambiguous(s::TwoBitSeq) = 0

--- a/src/longsequences/find.jl
+++ b/src/longsequences/find.jl
@@ -1,0 +1,20 @@
+# * iscertain + !iscertain
+#   Four bit: Certain bitcount OR enumerate_nibbles & 0x1111111 + tz
+#   AA: 0x00-0x15 or 0x1a
+#
+
+# * isambiguous + !isambiguous
+#   Four bit: Ambiguous bitcount OR enumerate_nibbles & 0xEEE.. + tz
+#   AA: 0x16-0x19
+
+# * isgap + !isgap
+#   Four: tz
+#   AA: 0x1b
+
+# * isGC + !isGC
+# * isequal / == 
+
+function findnext(iscertain, seq::SeqOrView{<:NucleicAcidAlphabet{4}}, from::Integer)
+    from = Int(from)::Int
+    @boundscheck (from < 1 && throw(BoundsError(seq, from)))
+end

--- a/src/longsequences/find.jl
+++ b/src/longsequences/find.jl
@@ -1,51 +1,90 @@
-# * iscertain + !iscertain
-#   Four bit: Certain bitcount OR enumerate_nibbles & 0x1111111 + tz
-#   AA: 0x00-0x15 or 0x1a
-#
-
-# * isambiguous + !isambiguous
-#   Four bit: Ambiguous bitcount OR enumerate_nibbles & 0xEEE.. + tz
-#   AA: 0x16-0x19
-
-# Make 0 for any other bitpattern than 0x1, 0x2, 0x4, 0x8.
-
 # Zeros out all nibbles except the ones with 4bit A,C,G or T
-function iscertain_kernel(x::UInt64)
+function iscertain_kernel(::NucleicAcidAlphabet{4}, x::UInt64)
     x = enumerate_nibbles(x)
-    y =  (x & 0x4444444444444444) >> 2
+    y = (x & 0x4444444444444444) >> 2
     y |= (x & 0x2222222222222222) >> 1
-    x & ~y & 0x1111111111111111
+    return x & ~y & 0x1111111111111111
 end
 
-# Zeros out all which is not a certain AA
-# TODO: This is not efficient.
-function iscertain_aa_kernel(x::UInt64)
-    y = reinterpret(NTuple{8, UInt8}, x)
-    y = map(i -> ((i < 0x16) | (i == 0x1a)), y)
-    reinterpret(UInt64, y)
+# Zeros out all which is not a certain (normal or AA_Term)
+function iscertain_kernel(::AminoAcidAlphabet, x::UInt64)
+    # 1. Set normal to FF, others to 00
+    y = simd_lt_byte(x, 0x16)
+
+    # 2. Set Term to FF, others to 00
+    z = set_zero_encoding(BitsPerSymbol{8}(), x ⊻ 0x1a1a1a1a1a1a1a1a) * 0xFF
+
+    # 3: OR them
+    return y | z
 end
 
+@inline function simd_lt_byte(x::UInt64, byte::UInt8)
+    T = NTuple{8, VecElement{UInt8}}
+    x = reinterpret(T, x)
+    y = ntuple(i -> VecElement(byte), Val{8}())
+    s = """
+    %res = icmp ult <8 x i8> %0, %1
+    %resb = sext <8 x i1> %res to <8 x i8>
+    ret <8 x i8> %resb
+    """
+    z = Core.Intrinsics.llvmcall(s, NTuple{8, VecElement{UInt8}}, Tuple{NTuple{8, VecElement{UInt8}}, NTuple{8, VecElement{UInt8}}}, x, y)
+    reinterpret(UInt64, z)
+end
+
+@inline function sub_byte(x::UInt64, byte::UInt8)
+    T = NTuple{8, VecElement{UInt8}}
+    x = reinterpret(T, x)
+    y = ntuple(i -> VecElement(byte), Val{8}())
+    s = """
+    %res = sub <8 x i8> %0, %1
+    ret <8 x i8> %res
+    """
+    z = Core.Intrinsics.llvmcall(s, NTuple{8, VecElement{UInt8}}, Tuple{NTuple{8, VecElement{UInt8}}, NTuple{8, VecElement{UInt8}}}, x, y)
+    reinterpret(UInt64, z)
+end
 
 # Zeros out all nibbles encoding 4bit A,C,G or T
-uncertain_kernel(x::UInt64) = enumerate_nibbles(x) ⊻ 0x1111111111111111
+uncertain_kernel(::NucleicAcidAlphabet{4}, x::UInt64) = enumerate_nibbles(x) ⊻ 0x1111111111111111
+
+# Zero out normal AAs and AA_Term
+function uncertain_kernel(::AminoAcidAlphabet, x::UInt64)
+    # Zero out normal AA, set rest to 0xFF
+    y = ~simd_lt_byte(x, 0x16)
+
+    # Zero out 0x1a, set rest to other bitpatterns
+    z = x ⊻ 0x1a1a1a1a1a1a1a1a
+
+    return y & z
+end
 
 # Zeros out A, C, G, T or Gap
-function ambiguous_kernel(x::UInt64)
+function ambiguous_kernel(A::NucleicAcidAlphabet{4}, x::UInt64)
     # The y part makes every nibble 0xF, unless it's 0 to begin with
     y = x | (x >>> 2)
     y |= y >>> 1
     y &= 0x1111111111111111
-    y *= 0xF
-    uncertain_kernel(x) & y
+    y *= 0x0F
+    return uncertain_kernel(A, x) & y
+end
+
+# Zero out all except ambiguous symbols (AA_B, AA_J, AA_Z, AA_X), 0x16:0x19
+function ambiguous_kernel(::AminoAcidAlphabet, x::UInt64)
+    return simd_lt_byte(sub_byte(x, 0x16), 0x04)
 end
 
 # Zeros out all except A, C, G, T and Gap
-function unambiguous_kernel(x::UInt64)
+function unambiguous_kernel(::NucleicAcidAlphabet{4}, x::UInt64)
     y = enumerate_nibbles(x)
     y = (y >>> 1) | (y >>> 2)
     y &= 0x1111111111111111
-    y ⊻= 0x1111111111111111
+    return y ⊻= 0x1111111111111111
 end
+
+# Zero out the four ambiguous amino acids B, J, Z, X
+function unambiguous_kernel(::AminoAcidAlphabet, x::UInt64)
+    return ~simd_lt_byte(sub_byte(x, 0x16), 0x04)
+end
+
 
 # For debug
 #=

--- a/src/longsequences/find.jl
+++ b/src/longsequences/find.jl
@@ -1,5 +1,5 @@
 # Zeros out all nibbles except the ones with 4bit A,C,G or T
-function iscertain_kernel(::NucleicAcidAlphabet{4}, x::UInt64)
+@inline function iscertain_kernel(::NucleicAcidAlphabet{4}, x::UInt64)
     x = enumerate_nibbles(x)
     y = (x & 0x4444444444444444) >> 2
     y |= (x & 0x2222222222222222) >> 1
@@ -7,7 +7,7 @@ function iscertain_kernel(::NucleicAcidAlphabet{4}, x::UInt64)
 end
 
 # Zeros out all which is not a certain (normal or AA_Term)
-function iscertain_kernel(::AminoAcidAlphabet, x::UInt64)
+@inline function iscertain_kernel(::AminoAcidAlphabet, x::UInt64)
     # 1. Set normal to FF, others to 00
     y = simd_lt_byte(x, 0x16)
 
@@ -16,6 +16,16 @@ function iscertain_kernel(::AminoAcidAlphabet, x::UInt64)
 
     # 3: OR them
     return y | z
+end
+
+function _findnext(::typeof(iscertain), seq::SeqOrView{<:Union{<:NucleicAcidAlphabet{4}, AminoAcidAlphabet}}, i::Int)
+    f = @inline u -> iscertain_kernel(Alphabet(seq), u)
+    return _findnext_nonzero(f, seq, i)
+end
+
+function _findprev(::typeof(iscertain), seq::SeqOrView{<:Union{<:NucleicAcidAlphabet{4}, AminoAcidAlphabet}}, i::Int)
+    f = @inline u -> iscertain_kernel(Alphabet(seq), u)
+    return _findprev_nonzero(f, seq, i)
 end
 
 @inline function simd_lt_byte(x::UInt64, byte::UInt8)
@@ -28,7 +38,7 @@ end
     ret <8 x i8> %resb
     """
     z = Core.Intrinsics.llvmcall(s, NTuple{8, VecElement{UInt8}}, Tuple{NTuple{8, VecElement{UInt8}}, NTuple{8, VecElement{UInt8}}}, x, y)
-    reinterpret(UInt64, z)
+    return reinterpret(UInt64, z)
 end
 
 @inline function sub_byte(x::UInt64, byte::UInt8)
@@ -40,14 +50,16 @@ end
     ret <8 x i8> %res
     """
     z = Core.Intrinsics.llvmcall(s, NTuple{8, VecElement{UInt8}}, Tuple{NTuple{8, VecElement{UInt8}}, NTuple{8, VecElement{UInt8}}}, x, y)
-    reinterpret(UInt64, z)
+    return reinterpret(UInt64, z)
 end
 
 # Zeros out all nibbles encoding 4bit A,C,G or T
-uncertain_kernel(::NucleicAcidAlphabet{4}, x::UInt64) = enumerate_nibbles(x) ⊻ 0x1111111111111111
+@inline function uncertain_kernel(::NucleicAcidAlphabet{4}, x::UInt64)
+    return enumerate_nibbles(x) ⊻ 0x1111111111111111
+end
 
 # Zero out normal AAs and AA_Term
-function uncertain_kernel(::AminoAcidAlphabet, x::UInt64)
+@inline function uncertain_kernel(::AminoAcidAlphabet, x::UInt64)
     # Zero out normal AA, set rest to 0xFF
     y = ~simd_lt_byte(x, 0x16)
 
@@ -57,8 +69,26 @@ function uncertain_kernel(::AminoAcidAlphabet, x::UInt64)
     return y & z
 end
 
+function _findnext(
+        ::ComposedFunction{typeof(!), typeof(iscertain)},
+        seq::SeqOrView{<:Union{<:NucleicAcidAlphabet{4}, AminoAcidAlphabet}},
+        i::Int,
+    )
+    f = @inline u -> uncertain_kernel(Alphabet(seq), u)
+    return _findnext_nonzero(f, seq, i)
+end
+
+function _findprev(
+        ::ComposedFunction{typeof(!), typeof(iscertain)},
+        seq::SeqOrView{<:Union{<:NucleicAcidAlphabet{4}, AminoAcidAlphabet}},
+        i::Int,
+    )
+    f = @inline u -> uncertain_kernel(Alphabet(seq), u)
+    return _findprev_nonzero(f, seq, i)
+end
+
 # Zeros out A, C, G, T or Gap
-function ambiguous_kernel(A::NucleicAcidAlphabet{4}, x::UInt64)
+@inline function ambiguous_kernel(A::NucleicAcidAlphabet{4}, x::UInt64)
     # The y part makes every nibble 0xF, unless it's 0 to begin with
     y = x | (x >>> 2)
     y |= y >>> 1
@@ -68,12 +98,22 @@ function ambiguous_kernel(A::NucleicAcidAlphabet{4}, x::UInt64)
 end
 
 # Zero out all except ambiguous symbols (AA_B, AA_J, AA_Z, AA_X), 0x16:0x19
-function ambiguous_kernel(::AminoAcidAlphabet, x::UInt64)
+@inline function ambiguous_kernel(::AminoAcidAlphabet, x::UInt64)
     return simd_lt_byte(sub_byte(x, 0x16), 0x04)
 end
 
+function _findnext(::typeof(isambiguous), seq::SeqOrView{<:Union{<:NucleicAcidAlphabet{4}, AminoAcidAlphabet}}, i::Int)
+    f = @inline u -> ambiguous_kernel(Alphabet(seq), u)
+    return _findnext_nonzero(f, seq, i)
+end
+
+function _findprev(::typeof(isambiguous), seq::SeqOrView{<:Union{<:NucleicAcidAlphabet{4}, AminoAcidAlphabet}}, i::Int)
+    f = @inline u -> ambiguous_kernel(Alphabet(seq), u)
+    return _findprev_nonzero(f, seq, i)
+end
+
 # Zeros out all except A, C, G, T and Gap
-function unambiguous_kernel(::NucleicAcidAlphabet{4}, x::UInt64)
+@inline function unambiguous_kernel(::NucleicAcidAlphabet{4}, x::UInt64)
     y = enumerate_nibbles(x)
     y = (y >>> 1) | (y >>> 2)
     y &= 0x1111111111111111
@@ -81,10 +121,27 @@ function unambiguous_kernel(::NucleicAcidAlphabet{4}, x::UInt64)
 end
 
 # Zero out the four ambiguous amino acids B, J, Z, X
-function unambiguous_kernel(::AminoAcidAlphabet, x::UInt64)
+@inline function unambiguous_kernel(::AminoAcidAlphabet, x::UInt64)
     return ~simd_lt_byte(sub_byte(x, 0x16), 0x04)
 end
 
+function _findnext(
+        ::ComposedFunction{typeof(!), typeof(isambiguous)},
+        seq::SeqOrView{<:Union{<:NucleicAcidAlphabet{4}, AminoAcidAlphabet}},
+        i::Int,
+    )
+    f = @inline u -> unambiguous_kernel(Alphabet(seq), u)
+    return _findnext_nonzero(f, seq, i)
+end
+
+function _findprev(
+        ::ComposedFunction{typeof(!), typeof(isambiguous)},
+        seq::SeqOrView{<:Union{<:NucleicAcidAlphabet{4}, AminoAcidAlphabet}},
+        i::Int,
+    )
+    f = @inline u -> unambiguous_kernel(Alphabet(seq), u)
+    return _findprev_nonzero(f, seq, i)
+end
 
 # For debug
 #=

--- a/src/longsequences/find.jl
+++ b/src/longsequences/find.jl
@@ -7,14 +7,53 @@
 #   Four bit: Ambiguous bitcount OR enumerate_nibbles & 0xEEE.. + tz
 #   AA: 0x16-0x19
 
-# * isgap + !isgap
-#   Four: tz
-#   AA: 0x1b
+# Make 0 for any other bitpattern than 0x1, 0x2, 0x4, 0x8.
 
-# * isGC + !isGC
-# * isequal / == 
-
-function findnext(iscertain, seq::SeqOrView{<:NucleicAcidAlphabet{4}}, from::Integer)
-    from = Int(from)::Int
-    @boundscheck (from < 1 && throw(BoundsError(seq, from)))
+# Zeros out all nibbles except the ones with 4bit A,C,G or T
+function iscertain_kernel(x::UInt64)
+    x = enumerate_nibbles(x)
+    y =  (x & 0x4444444444444444) >> 2
+    y |= (x & 0x2222222222222222) >> 1
+    x & ~y & 0x1111111111111111
 end
+
+# Zeros out all which is not a certain AA
+# TODO: This is not efficient.
+function iscertain_aa_kernel(x::UInt64)
+    y = reinterpret(NTuple{8, UInt8}, x)
+    y = map(i -> ((i < 0x16) | (i == 0x1a)), y)
+    reinterpret(UInt64, y)
+end
+
+
+# Zeros out all nibbles encoding 4bit A,C,G or T
+uncertain_kernel(x::UInt64) = enumerate_nibbles(x) ⊻ 0x1111111111111111
+
+# Zeros out A, C, G, T or Gap
+function ambiguous_kernel(x::UInt64)
+    # The y part makes every nibble 0xF, unless it's 0 to begin with
+    y = x | (x >>> 2)
+    y |= y >>> 1
+    y &= 0x1111111111111111
+    y *= 0xF
+    uncertain_kernel(x) & y
+end
+
+# Zeros out all except A, C, G, T and Gap
+function unambiguous_kernel(x::UInt64)
+    y = enumerate_nibbles(x)
+    y = (y >>> 1) | (y >>> 2)
+    y &= 0x1111111111111111
+    y ⊻= 0x1111111111111111
+end
+
+# For debug
+#=
+function make_all_nibbles()
+    x = UInt64(0)
+    for i in 0:15
+        x = (x << 4) | i
+    end
+    x
+end
+=#

--- a/src/longsequences/longsequence.jl
+++ b/src/longsequences/longsequence.jl
@@ -120,3 +120,9 @@ include("copying.jl")
 include("stringliterals.jl")
 include("transformations.jl")
 include("operators.jl")
+
+const FourBit = SeqOrView{<:NucleicAcidAlphabet{4}}
+const TwoBit = SeqOrView{<:NucleicAcidAlphabet{2}}
+
+const TwoBitSeq = BioSequence{<:NucleicAcidAlphabet{2}}
+const FourBitSeq = BioSequence{<:NucleicAcidAlphabet{4}}

--- a/src/longsequences/operators.jl
+++ b/src/longsequences/operators.jl
@@ -263,17 +263,13 @@ function Base.:(==)(seq1::LongSequence{A}, seq2::LongSequence{A}) where {A <: Al
 end
 
 ## Search
-function Base.findnext(::typeof(isgap), seq::SeqOrView{<:KNOWN_ALPHABETS}, i::Integer)
-    findnext(==(gap(eltype(seq))), seq, i)
-end
-
 # We only dispatch on known alphabets, because new alphabets may implement == in surprising ways
-function Base.findnext(
+function _findnext(
     cmp::Base.Fix2{<:Union{typeof(==), typeof(isequal)}},
     seq::SeqOrView{<:KNOWN_ALPHABETS},
-    i::Integer,
+    i::Int,
 )
-    i = max(Int(i)::Int, 1)
+    i = max(i, 1)
     i > length(seq) && return nothing
     symbol = cmp.x
     enc = tryencode(Alphabet(seq), symbol)
@@ -320,16 +316,11 @@ function _findfirst(seq::SeqOrView{<:KNOWN_ALPHABETS}, enc::UInt64)
     nothing
 end
 
-function Base.findprev(::typeof(isgap), seq::SeqOrView{<:KNOWN_ALPHABETS}, i::Integer)
-    findprev(==(gap(eltype(seq))), seq, i)
-end
-
-function Base.findprev(
+function _findprev(
     cmp::Base.Fix2{<:Union{typeof(==), typeof(isequal)}},
     seq::SeqOrView{<:KNOWN_ALPHABETS},
-    i::Integer,
+    i::Int,
 )
-    i = Int(i)::Int
     i < 1 && return nothing
     symbol = cmp.x
     enc = tryencode(Alphabet(seq), symbol)

--- a/src/longsequences/operators.jl
+++ b/src/longsequences/operators.jl
@@ -388,11 +388,10 @@ function _findlast_nonzero(f::Function, seq::SeqOrView{<:KNOWN_ALPHABETS})
     # This part is slightly different, because the coding bits are shifted to the right,
     # but we need to count the leading bits.
     # So, we set all the unused bits to zero, then count leading zeros, and then
-    # ignore the unused zero bits.
+    # subtract the unused bits from the leading zero count
     mask = (UInt(1) << (tail_bits & 63)) - 1
     lz = leading_zeros(f(tail) & mask)
     if lz < 64
-        # Compensate for@inbounds(data[body_i]) noncoding zero bits
         zero_symbols = div((lz - (64 - tail_bits)) % UInt, bps) % Int
         return i - zero_symbols
     end

--- a/src/longsequences/operators.jl
+++ b/src/longsequences/operators.jl
@@ -273,9 +273,7 @@ function _findnext(
     enc === nothing && return nothing
     u_enc = enc * encoding_expansion(BitsPerSymbol(seq))
     f = x -> set_zero_encoding(BitsPerSymbol(seq), x ⊻ u_enc)
-    vw = @inbounds view(seq, i:lastindex(seq))
-    res = _findfirst_nonzero(f, vw)
-    res === nothing ? nothing : res + i - 1
+    _findnext_nonzero(f, seq, i)
 end
 
 function _findnext(
@@ -287,10 +285,19 @@ function _findnext(
     enc === nothing && return nothing
     u_enc = enc * encoding_expansion(BitsPerSymbol(seq))
     f = x -> x ⊻ u_enc
+    _findnext_nonzero(f, seq, i)
+end
+
+@inline function _findnext_nonzero(
+    f,
+    seq::SeqOrView{<:KNOWN_ALPHABETS},
+    i::Int,
+)
     vw = @inbounds view(seq, i:lastindex(seq))
     res = _findfirst_nonzero(f, vw)
     res === nothing ? nothing : res + i - 1
 end
+
 
 # Find first index of seq, where f is a function that takes an encodung UInt64
 # and will zero out every coding element we are not looking for.
@@ -348,8 +355,7 @@ function _findprev(
     enc === nothing && return nothing
     u_enc = enc * encoding_expansion(BitsPerSymbol(seq))
     f = x -> set_zero_encoding(BitsPerSymbol(seq), x ⊻ u_enc)
-    vw = @inbounds view(seq, 1:i)
-    _findlast_nonzero(f, vw)
+    _findprev_nonzero(f, seq, i)
 end
 
 function _findprev(
@@ -361,6 +367,14 @@ function _findprev(
     enc === nothing && return nothing
     u_enc = enc * encoding_expansion(BitsPerSymbol(seq))
     f = x -> x ⊻ u_enc
+    _findprev_nonzero(f, seq, i)
+end
+
+function _findprev_nonzero(
+    f,
+    seq::SeqOrView{<:KNOWN_ALPHABETS},
+    i::Int,
+)
     vw = @inbounds view(seq, 1:i)
     _findlast_nonzero(f, vw)
 end

--- a/src/longsequences/operators.jl
+++ b/src/longsequences/operators.jl
@@ -269,50 +269,73 @@ function _findnext(
     seq::SeqOrView{<:KNOWN_ALPHABETS},
     i::Int,
 )
-    i = max(i, 1)
-    i > length(seq) && return nothing
-    symbol = cmp.x
-    enc = tryencode(Alphabet(seq), symbol)
+    enc = tryencode(Alphabet(seq), cmp.x)
     enc === nothing && return nothing
+    u_enc = enc * encoding_expansion(BitsPerSymbol(seq))
+    f = x -> set_zero_encoding(BitsPerSymbol(seq), x ⊻ u_enc)
     vw = @inbounds view(seq, i:lastindex(seq))
-    res = _findfirst(vw, enc)
+    res = _findfirst_nonzero(f, vw)
     res === nothing ? nothing : res + i - 1
 end
 
-function _findfirst(seq::SeqOrView{<:KNOWN_ALPHABETS}, enc::UInt64)
+function _findnext(
+    cmp::Union{<:Base.Fix2{typeof(!=)}, ComposedFunction{typeof(!), <:Base.Fix2{typeof(isequal)}}},
+    seq::SeqOrView{<:KNOWN_ALPHABETS},
+    i::Int,
+)
+    enc = tryencode(Alphabet(seq), cmp.x)
+    enc === nothing && return nothing
+    u_enc = enc * encoding_expansion(BitsPerSymbol(seq))
+    f = x -> x ⊻ u_enc
+    vw = @inbounds view(seq, i:lastindex(seq))
+    res = _findfirst_nonzero(f, vw)
+    res === nothing ? nothing : res + i - 1
+end
+
+# Find first index of seq, where f is a function that takes an encodung UInt64
+# and will zero out every coding element we are not looking for.
+function _findfirst_nonzero(f::Function, seq::SeqOrView{<:KNOWN_ALPHABETS})
     data = seq.data
-    enc *= encoding_expansion(BitsPerSymbol(seq))
     ((head, head_bits), (body_i, body_stop), (tail, tail_bits)) = parts(seq)
-    symbols_in_head = div(head_bits, bits_per_symbol(Alphabet(seq))) % Int
-    # The idea here is that we xor with the coding elements, then check for the first
-    # occurrence of a zerod symbol, if any.
-    if !iszero(head_bits)
-        tu = trailing_unsets(BitsPerSymbol(seq), head ⊻ enc)
-        tu < symbols_in_head && return tu + 1
-    end
-    i = symbols_in_head + 1
+    bps = bits_per_symbol(Alphabet(seq))
+    
+    # Use f to zero out all coding bits in head, and then mask to make sure all
+    # noncoding bits are zero. Then, the chunk will be all zero if the element
+    # we are not looking for is here.
+    mask = (UInt(1) << (head_bits & 63)) - 1
+    tz = trailing_zeros(f(head) & mask)
+    tz < 64 && return div(tz % UInt, bps) % Int + 1
+    # i is the current position. We just checked the head.
+    i = div(head_bits % UInt, bps) % Int + 1
+
+    # Now, process 8*64 bits at a time to improve SIMD, simply
+    # skipping them if they are all zero.
     unroll = 8
     while body_i + unroll - 2 < body_stop
         u = zero(UInt64)
         for j in 0:unroll - 1
-            u |= set_zero_encoding(BitsPerSymbol(seq), @inbounds(data[body_i + j]) ⊻ enc)
+            u |= f(@inbounds(data[body_i + j]))
         end
         iszero(u) || break
         i += symbols_per_data_element(seq) * unroll
         body_i += unroll
     end
+
+    # Check the remaining full chunks
     while body_i ≤ body_stop
-        ze = set_zero_encoding(BitsPerSymbol(seq), @inbounds(data[body_i]) ⊻ enc)
-        if !iszero(ze)
-            return i + div(trailing_zeros(ze) % UInt, bits_per_symbol(Alphabet(seq))) % Int
-        end 
+        u = f(@inbounds(data[body_i]))
+        if !iszero(u)
+            tz = trailing_zeros(u)
+            return i + div(tz % UInt, bps) % Int
+        end
         body_i += 1
         i += symbols_per_data_element(seq)
     end
-    if !iszero(tail_bits)
-        tu = trailing_unsets(BitsPerSymbol(seq), tail ⊻ enc)
-        tu < div(tail_bits, bits_per_symbol(Alphabet(seq))) && return tu + i
-    end
+    
+    # This is similar to the head
+    mask = (UInt(1) << (tail_bits & 63)) - 1
+    tz = trailing_zeros(f(tail) & mask)
+    tz < 64 && return div(tz % UInt, bps) % Int + i
     nothing
 end
 
@@ -321,58 +344,72 @@ function _findprev(
     seq::SeqOrView{<:KNOWN_ALPHABETS},
     i::Int,
 )
-    i < 1 && return nothing
-    symbol = cmp.x
-    enc = tryencode(Alphabet(seq), symbol)
+    enc = tryencode(Alphabet(seq), cmp.x)
     enc === nothing && return nothing
+    u_enc = enc * encoding_expansion(BitsPerSymbol(seq))
+    f = x -> set_zero_encoding(BitsPerSymbol(seq), x ⊻ u_enc)
     vw = @inbounds view(seq, 1:i)
-    _findlast(vw, enc)
+    _findlast_nonzero(f, vw)
 end
 
-# See comments in findfirst
-function _findlast(seq::SeqOrView{<:KNOWN_ALPHABETS}, enc::UInt64)
+function _findprev(
+    cmp::Union{<:Base.Fix2{typeof(!=)}, ComposedFunction{typeof(!), <:Base.Fix2{typeof(isequal)}}},
+    seq::SeqOrView{<:KNOWN_ALPHABETS},
+    i::Int,
+)
+    enc = tryencode(Alphabet(seq), cmp.x)
+    enc === nothing && return nothing
+    u_enc = enc * encoding_expansion(BitsPerSymbol(seq))
+    f = x -> x ⊻ u_enc
+    vw = @inbounds view(seq, 1:i)
+    _findlast_nonzero(f, vw)
+end
+
+# See comments in the findfirst version of this function
+function _findlast_nonzero(f::Function, seq::SeqOrView{<:KNOWN_ALPHABETS})
     data = seq.data
-    enc *= encoding_expansion(BitsPerSymbol(seq))
     ((head, head_bits), (body_stop, body_i), (tail, tail_bits)) = parts(seq)
     i = lastindex(seq)
+    bps = bits_per_symbol(Alphabet(seq))
     # This part is slightly different, because the coding bits are shifted to the right,
     # but we need to count the leading bits.
-    # So, we need to mask off the top bits by OR'ing them with a bunch of 1's,
-    # and then ignore the number of symbols we've masked off when counting the number
-    # of leading nonzero symbols un the encoding
-    if !iszero(tail_bits)
-        symbols_in_tail = div(tail_bits, bits_per_symbol(Alphabet(seq))) % Int
-        tail = (tail ⊻ enc) | ~(UInt64(1) << (tail_bits & 0x3f) - 1)
-        masked_unsets = div((0x40 - tail_bits), bits_per_symbol(Alphabet(seq)))
-        lu = leading_unsets(BitsPerSymbol(seq), tail) - masked_unsets
-        lu < symbols_in_tail && return (i - lu) % Int
-        i -= lu
+    # So, we set all the unused bits to zero, then count leading zeros, and then
+    # ignore the unused zero bits.
+    mask = (UInt(1) << (tail_bits & 63)) - 1
+    lz = leading_zeros(f(tail) & mask)
+    if lz < 64
+        # Compensate for@inbounds(data[body_i]) noncoding zero bits
+        zero_symbols = div((lz - (64 - tail_bits)) % UInt, bps) % Int
+        return i - zero_symbols
     end
+    i -= div(tail_bits % UInt, bps) % Int
     unroll = 8
-    (body_i, body_stop) = (body_i % Int, body_stop % Int)  
+    # Cast to signed to prevent overflow
+    (body_i, body_stop) = (body_i % Int, body_stop % Int)
     while body_i - unroll + 2 > body_stop
         u = zero(UInt64)
         for j in 0:unroll - 1
-            u |= set_zero_encoding(BitsPerSymbol(seq), @inbounds(data[body_i - j]) ⊻ enc)
+            u |= f(@inbounds(data[body_i - j]))
         end
         iszero(u) || break
         i -= symbols_per_data_element(seq) * unroll
         body_i -= unroll
     end
     while body_i ≥ body_stop
-        ze = set_zero_encoding(BitsPerSymbol(seq), @inbounds(data[body_i]) ⊻ enc)
-        if !iszero(ze)
-            return i - div(leading_zeros(ze) % UInt, bits_per_symbol(Alphabet(seq))) % Int
-        end 
+        u = f(@inbounds(data[body_i]))
+        if !iszero(u)
+           lz = leading_zeros(u)
+           leading_symbols = (div(lz % UInt, bps) % Int)
+           return i - leading_symbols
+        end
         body_i -= 1
         i -= symbols_per_data_element(seq)
     end
-    if !iszero(head_bits)
-        symbols_in_head = div(head_bits, bits_per_symbol(Alphabet(seq))) % Int
-        head = (head ⊻ enc) | ~(UInt64(1) << (head_bits & 0x3f) - 1)
-        masked_unsets = div((0x40 - head_bits), bits_per_symbol(Alphabet(seq)))
-        lu = leading_unsets(BitsPerSymbol(seq), head) - masked_unsets
-        lu < symbols_in_head && return (i - lu) % Int
+    mask = (UInt(1) << (head_bits & 63)) - 1
+    lz = leading_zeros(f(head) & mask)
+    if lz < 64
+        zero_symbols = div((lz - (64 - head_bits)) % UInt, bps) % Int
+        return i - zero_symbols
     end
     nothing
 end
@@ -403,15 +440,4 @@ function set_zero_encoding(B::BitsPerSymbol{2}, enc::UInt64)
     enc = ~enc
     enc &= enc >> 1
     enc & encoding_expansion(B)
-end
-
-# Count how many trailing chunks of B bits in encoding that are not all zeros
-function trailing_unsets(::BitsPerSymbol{B}, enc::UInt64) where B
-    u = set_zero_encoding(BitsPerSymbol{B}(), enc)
-    div(trailing_zeros(u) % UInt, B) % Int
-end
-
-function leading_unsets(::BitsPerSymbol{B}, enc::UInt64) where B
-    u = set_zero_encoding(BitsPerSymbol{B}(), enc)
-    div(leading_zeros(u) % UInt, B) % Int
 end

--- a/test/longsequences/find.jl
+++ b/test/longsequences/find.jl
@@ -155,8 +155,12 @@ end
             (!isambiguous, DNAAlphabet{4}()),
             (!isambiguous, AminoAcidAlphabet()),
             (iscertain, DNAAlphabet{4}()),
+            (iscertain, AminoAcidAlphabet()),
+            (!iscertain, DNAAlphabet{4}()),
             (!iscertain, AminoAcidAlphabet()),
             (isgap, DNAAlphabet{4}()),
+            (isgap, AminoAcidAlphabet()),
+            (!isgap, DNAAlphabet{4}()),
             (!isgap, AminoAcidAlphabet()),
         ]
             yes, no = Any[], Any[]


### PR DESCRIPTION
This adds SIMD optimised methods for `findprev` and `findnext` (and therefore, by extension `findfirst` and `findlast`) for the predicates `!isgap`, `iscertain`, `!iscertain`, `isambiguous` and `!isambiguous` for the default alphabets for LongSequence and LongSubSeq

The purpose of these is to find e.g. regions of N's in a sequence, or find the first symbol in a long DNA sequence which is not a gap or an unambiguous symbol.

Some benchmarks for AA - nucleotide benchmarks are even better:
```julia
s = randaaseq(100_000)
@btime findfirst(isgap, s)
@btime findfirst(isambiguous, s)
@btime findfirst(!iscertain, s)
for i in eachindex(s)
   s[i] = AA_B
end
@btime findfirst(!isambiguous, s)
@btime findfirst(iscertain, s)
```
Before:
  1.738 μs (0 allocations: 0 bytes)
  39.195 μs (0 allocations: 0 bytes)
  39.195 μs (0 allocations: 0 bytes)
  39.205 μs (0 allocations: 0 bytes)
  39.205 μs (0 allocations: 0 bytes)

After:
  1.894 μs (0 allocations: 0 bytes)
  3.270 μs (0 allocations: 0 bytes)
  5.500 μs (0 allocations: 0 bytes)
  3.240 μs (0 allocations: 0 bytes)
  4.530 μs (0 allocations: 0 bytes)