### PR TITLE
hashing can maybe be faster

### DIFF
--- a/src/biosequence/biosequence.jl
+++ b/src/biosequence/biosequence.jl
@@ -109,7 +109,9 @@ Base.empty(x::BioSequence) = empty(typeof(x))
 BitsPerSymbol(x::BioSequence) = BitsPerSymbol(Alphabet(typeof(x)))
 bits_per_symbol(::Type{T}) where {T <: BioSequence} = bits_per_symbol(Alphabet(T))
 bits_per_symbol(x::BioSequence) = bits_per_symbol(typeof(x))
-Base.hash(s::BioSequence, x::UInt) = foldl((a, b) -> hash(b, a), s, init=x)
+
+const biosequencehash_seed = 0xd3f2809990a31c79
+Base.hash(s::BioSequence, x::UInt) = Base.hash_shaped(s, x ⊻ biosequencehash_seed)
 
 function Base.similar(seq::BioSequence, len::Integer=length(seq))
     return typeof(seq)(undef, len)

--- a/src/biosequence/biosequence.jl
+++ b/src/biosequence/biosequence.jl
@@ -109,9 +109,7 @@ Base.empty(x::BioSequence) = empty(typeof(x))
 BitsPerSymbol(x::BioSequence) = BitsPerSymbol(Alphabet(typeof(x)))
 bits_per_symbol(::Type{T}) where {T <: BioSequence} = bits_per_symbol(Alphabet(T))
 bits_per_symbol(x::BioSequence) = bits_per_symbol(typeof(x))
-
-const biosequencehash_seed = 0xd3f2809990a31c79
-Base.hash(s::BioSequence, x::UInt) = Base.hash_shaped(s, x ⊻ biosequencehash_seed)
+Base.hash(s::BioSequence, x::UInt) = Base.hash_shaped(s, x)
 
 function Base.similar(seq::BioSequence, len::Integer=length(seq))
     return typeof(seq)(undef, len)

--- a/src/biosequence/biosequence.jl
+++ b/src/biosequence/biosequence.jl
@@ -109,7 +109,12 @@ Base.empty(x::BioSequence) = empty(typeof(x))
 BitsPerSymbol(x::BioSequence) = BitsPerSymbol(Alphabet(typeof(x)))
 bits_per_symbol(::Type{T}) where {T <: BioSequence} = bits_per_symbol(Alphabet(T))
 bits_per_symbol(x::BioSequence) = bits_per_symbol(typeof(x))
-Base.hash(s::BioSequence, x::UInt) = Base.hash_shaped(s, x)
+
+@static if isdefined(Base, :hash_shaped)
+    Base.hash(s::BioSequence, x::UInt) = Base.hash_shaped(s, x)
+else
+    Base.hash(s::BioSequence, x::UInt) = foldl((a, b) -> hash(b, a), s, init=x)
+end
 
 function Base.similar(seq::BioSequence, len::Integer=length(seq))
     return typeof(seq)(undef, len)


### PR DESCRIPTION
after https://github.com/JuliaLang/julia/pull/58252

I saw in code search your hashing method here (using `foldl`)

I think the new `hash_shaped` will be faster, especially on longer sequences (though maybe slightly slower on short ones)

I'm seeing before:

```
julia> using BioSequences, BenchmarkTools

julia> for i in 1:6
           s = dna"ACGTACGT"[1:i]
           @btime hash($s)
       end
  3.625 ns (0 allocations: 0 bytes)
  3.917 ns (0 allocations: 0 bytes)
  4.250 ns (0 allocations: 0 bytes)
  4.958 ns (0 allocations: 0 bytes)
  6.375 ns (0 allocations: 0 bytes)
  7.833 ns (0 allocations: 0 bytes)

julia> for i in vcat(1:3, 6:5:21)
           s = dna"ACGTACGT"^i
           @btime hash($s)
       end
  10.969 ns (0 allocations: 0 bytes)
  25.853 ns (0 allocations: 0 bytes)
  48.287 ns (0 allocations: 0 bytes)
  113.781 ns (0 allocations: 0 bytes)
  250.789 ns (0 allocations: 0 bytes)
  389.025 ns (0 allocations: 0 bytes)
  525.084 ns (0 allocations: 0 bytes)
```

after
```
julia> for i in 1:6
           s = dna"ACGTACGT"[1:i]
           @btime hash($s)
       end
  4.583 ns (0 allocations: 0 bytes)
  5.166 ns (0 allocations: 0 bytes)
  6.291 ns (0 allocations: 0 bytes)
  7.750 ns (0 allocations: 0 bytes)
  9.417 ns (0 allocations: 0 bytes)
  10.844 ns (0 allocations: 0 bytes)


julia> for i in vcat(1:3, 6:5:21)
           s = dna"ACGTACGT"^i
           @btime hash($s)
       end
  13.514 ns (0 allocations: 0 bytes)
  21.000 ns (0 allocations: 0 bytes)
  28.559 ns (0 allocations: 0 bytes)
  51.249 ns (0 allocations: 0 bytes)
  89.105 ns (0 allocations: 0 bytes)
  126.902 ns (0 allocations: 0 bytes)
  164.700 ns (0 allocations: 0 bytes)
```

so the crossover point I suppose is around 10-15 characters. I am not a user of this package so you would have to tell me what lengths are most commonly seen (short or long)


since the eltype is `<: Alphabet` I think a salt is not needed to avoid collisions with other `AbstractArray`s, but if you want to be even safer this could be instead
```
const biosequencehash_seed = 0xd3f2809990a31c79 % UInt
Base.hash(s::BioSequence, x::UInt) = Base.hash_shaped(s, x ⊻ biosequencehash_seed)

```