### PR TITLE
Add `spliceinto!` function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.5.0]
+* Add `spliceinto!`. This function inserts a sequence into a biosequence,
+  and optionally deletes part of the original sequence. The naming difference
+  from `Base.splice!` reflects is slightly different API.
+* Optimise various methods
+
 ## [3.4.0]
 * Deprecate functions `n_ambiguous`, `n_gaps` and `n_certain`. Instead, use the
   equivalent methods `count(f, seq)` with the appropriate function `f`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BioSequences"
 uuid = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 authors = ["Sabrina Jaye Ward <sabrinajward@protonmail.com>", "Jakob Nissen <jakobnybonissen@gmail.com>"]
-version = "3.4.2"
+version = "3.5.0"
 
 [deps]
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"

--- a/Project.toml
+++ b/Project.toml
@@ -11,14 +11,17 @@ Twiddle = "7200193e-83a8-5a55-b20d-5d36d44a0795"
 
 [compat]
 BioSymbols = "5.1.2"
+LinearAlgebra = "1.10"
 PrecompileTools = "1"
 Random = "1.5"
 StableRNGs = "0.1, 1.0"
+StatsBase = "0.34.5"
+Test = "1.10"
 Twiddle = "1.1.1"
+YAML = "0.4.14"
 julia = "1.10"
 
 [extras]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
@@ -26,4 +29,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [targets]
-test = ["Documenter", "Test", "StatsBase", "YAML", "LinearAlgebra", "StableRNGs"]
+test = ["Test", "StatsBase", "YAML", "LinearAlgebra", "StableRNGs"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,5 +3,8 @@ BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
+[sources]
+BioSequences = {path = ".."}
+
 [compat]
 Documenter = "1"

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -66,6 +66,8 @@ deleteat!(::BioSequences.BioSequence, ::Integer)
 append!(::BioSequences.BioSequence, ::BioSequences.BioSequence)
 resize!(::BioSequences.LongSequence, ::Integer)
 empty!(::BioSequences.BioSequence)
+spliceinto!(::BioSequence, ::Integer, ::Any)
+spliceinto!(::BioSequence, ::UnitRange, ::Any)
 ```
 
 Here are some examples:

--- a/src/BioSequences.jl
+++ b/src/BioSequences.jl
@@ -132,6 +132,7 @@ export
     ungap,
     ungap!,
     join!,
+    spliceinto!,
 
     ###
     ### LongSequence

--- a/src/biosequence/transformations.jl
+++ b/src/biosequence/transformations.jl
@@ -57,11 +57,7 @@ julia> insert!(seq, 3, 'A')
 ATAGCA
 ```
 """
-function Base.insert!(
-        seq::BioSequence,
-        i::Integer,
-        x
-    )
+function Base.insert!(seq::BioSequence, i::Integer, x)
     i == length(seq) + 1 && return push!(seq, x)
     checkbounds(seq, i)
     resize!(seq, length(seq) + 1)

--- a/src/biosequence/transformations.jl
+++ b/src/biosequence/transformations.jl
@@ -170,7 +170,7 @@ end
 Add a biological sequence `other` onto the end of biological sequence `seq`.
 Modifies and returns `seq`.
 """
-function Base.append!(seq::BioSequence, other::BioSequence)
+function Base.append!(seq::BioSequence, other)
     resize!(seq, length(seq) + length(other))
     copyto!(seq, lastindex(seq) - length(other) + 1, other, 1, length(other))
     return seq

--- a/test/longsequences/mutability.jl
+++ b/test/longsequences/mutability.jl
@@ -125,6 +125,83 @@
         @test_throws BoundsError insert!(seq, 10, DNA_T)
     end
 
+    @testset "spliceinto!" begin
+        @testset "spliceinto integer" begin
+            function manual_spliceinto(seq, i, x)
+                s = typeof(seq)(undef, length(seq) + length(x))
+                copyto!(s, 1, seq, 1, i-1)
+                copyto!(s, i, x, 1, length(x))
+                copyto!(s, i + length(x), seq, i, length(seq)-i+1)
+                return s
+            end
+
+            seq = dna"TAGTGCA"
+            @test spliceinto!(seq, 2, "CA") === seq
+            @test seq == dna"TCAAGTGCA"
+
+            str = "ATGTGCTCGTGTCGTGATAGTGAGTAGTAGTCGTAGTAGTGATTGCTGTAGTA"
+            seq = LongDNA{2}(str)
+
+            @test_throws BoundsError spliceinto!(seq, 0, "CA")
+            @test_throws BoundsError spliceinto!(seq, -1, "CA")
+            @test_throws BoundsError spliceinto!(seq, length(seq) + 2, "CA")
+
+            for (i, s) in Any[
+                (1, ""),
+                (1, "CAC"),
+                (1, "ATGCTGCTGATGTGATGA"),
+                (2, dna"ATGTCGA"),
+                (15, rna"AUGUCGUAGUAACCAACA"),
+                (16, dna"ATGTCGTGATGATGTAGTGTCGTA"),
+                (18, b"ATGCTGTGATGATGTCC"),
+                (length(seq), dna"TAGCGGAGA"),
+                (length(seq) + 1, "AGCGGGAGA"),
+            ]
+                copy!(seq, str)
+                cp = copy(seq)
+                @test spliceinto!(seq, i, s) == manual_spliceinto(cp, i, s)
+            end
+        end
+
+        @testset "spliceinto span" begin
+            function manual_spliceinto(seq, span, x)
+                deleteat!(seq, span)
+                spliceinto!(seq, first(span), x)
+                return seq
+            end
+
+            seq = dna"ATGTCGTGA"
+            @test spliceinto!(seq, 2:2, "CA") === seq
+            @test seq == dna"ACAGTCGTGA"
+
+            str = "ATGTGCTCGTGTCGTGATAGTGAGTAGTAGTCGTAGTAGTGATTGCTGTAGTA"
+            seq = LongDNA{2}(str)
+
+            @test_throws ArgumentError spliceinto!(seq, 0:-1, "CA")
+            @test_throws ArgumentError spliceinto!(seq, 1:0, "CA")
+            @test_throws ArgumentError spliceinto!(seq, lastindex(seq):5, "CA")
+
+            @test_throws BoundsError spliceinto!(seq, 0:0, "CA")
+            @test_throws BoundsError spliceinto!(seq, 0:1, "CA")
+            @test_throws BoundsError spliceinto!(seq, 4:100, "CA")
+            @test_throws BoundsError spliceinto!(seq, length(seq):length(seq)+1, "CA")
+
+            for (i, s) in Any[
+                (1:1, ""),
+                (4:6, "T"),
+                (4:9, "ATGCGTA"),
+                (3:6, "AGCA"),
+                (30:35, "ATGTCGTAG"),
+                (15:20, rna"UAGC"),
+                (9:40, dna"ATGTCGTGATGAA")
+            ]
+                copy!(seq, str)
+                cp = copy(seq)
+                @test spliceinto!(seq, i, s) == manual_spliceinto(cp, i, s)
+            end
+        end
+    end
+
     @testset "deleteat!" begin
         seq = dna"ACGT"
         @test deleteat!(seq, 1) == dna"CGT"

--- a/test/longsequences/mutability.jl
+++ b/test/longsequences/mutability.jl
@@ -122,6 +122,8 @@
         seq = dna"ACGT"
         @test insert!(seq, 2, DNA_G) == dna"AGCGT"
         @test insert!(seq, 5, DNA_A) == dna"AGCGAT"
+        @test insert!(seq, 1, 'G') == dna"GAGCGAT"
+        @test insert!(seq, length(seq) + 1, 'C') == dna"GAGCGATC"
         @test_throws BoundsError insert!(seq, 10, DNA_T)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 module TestBioSequences
 
 using Test
-using Documenter
 
 using Random
 using StableRNGs


### PR DESCRIPTION
Fixes #336 

@pdimens - I'm interested in feedback. Does this cover your use case, and what do you think of the API?
The reason for the deviation from `splice!` is:
* It bugs me that `4:3 == 5:4`, and yet passing these equal arrays into `splice!` causes different behaviour
* It's unnecessary and inefficient that `splice!` returns the removed sequence

By the way, if you need this function now and can't wait for the 3.5.0 release (which will happen once this PR is merged), or need compat with older versions of BioSequences, you can use the implmentation from this PR. It's efficient, and uses no internals.