### PR TITLE
Do not uselessly precompile in Downstream CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -42,8 +42,9 @@ jobs:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Load this and run the downstream tests
-        shell: JULIA_PKG_PRECOMPILE_AUTO=0 julia --color=yes --project=downstream {0}
+        shell: julia --color=yes --project=downstream {0}
         run: |
+          ENV["JULIA_PKG_PRECOMPILE_AUTO"] = 0
           using Pkg
           try
             # force it to use this PR's version of the package

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -42,7 +42,7 @@ jobs:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
+        shell: JULIA_PKG_PRECOMPILE_AUTO=0 julia --color=yes --project=downstream {0}
         run: |
           using Pkg
           try


### PR DESCRIPTION
Previously, it would precompile the dep after installing, and then launch a new test process with different settings and precompile again. Disable the first precompilation.

